### PR TITLE
Add skeleton for My Todo Flutter app

### DIFF
--- a/my_todo_app/.gitignore
+++ b/my_todo_app/.gitignore
@@ -1,0 +1,10 @@
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.packages
+.pub/
+build/
+
+# IDE files
+.idea/
+.vscode/

--- a/my_todo_app/README.md
+++ b/my_todo_app/README.md
@@ -1,0 +1,3 @@
+# My Todo App
+
+A simple Flutter to-do application.

--- a/my_todo_app/lib/main.dart
+++ b/my_todo_app/lib/main.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'ui/home_page.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Todo App',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}

--- a/my_todo_app/lib/models/task.dart
+++ b/my_todo_app/lib/models/task.dart
@@ -1,0 +1,10 @@
+class Task {
+  final String title;
+  bool isDone;
+
+  Task({required this.title, this.isDone = false});
+
+  void toggleDone() {
+    isDone = !isDone;
+  }
+}

--- a/my_todo_app/lib/services/storage_service.dart
+++ b/my_todo_app/lib/services/storage_service.dart
@@ -1,0 +1,10 @@
+class StorageService {
+  Future<void> saveTaskList(List<String> tasks) async {
+    // TODO: implement persistent storage
+  }
+
+  Future<List<String>> loadTaskList() async {
+    // TODO: implement persistent storage
+    return <String>[];
+  }
+}

--- a/my_todo_app/lib/ui/home_page.dart
+++ b/my_todo_app/lib/ui/home_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+import 'task_tile.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  final List<Task> _tasks = [];
+  final TextEditingController _controller = TextEditingController();
+
+  void _addTask(String title) {
+    setState(() {
+      _tasks.add(Task(title: title));
+    });
+    _controller.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('My Todo App')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(labelText: 'Add task'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add),
+                  onPressed: () => _addTask(_controller.text),
+                )
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _tasks.length,
+              itemBuilder: (context, index) {
+                final task = _tasks[index];
+                return TaskTile(task: task, onChanged: () => setState(task.toggleDone));
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/my_todo_app/lib/ui/task_tile.dart
+++ b/my_todo_app/lib/ui/task_tile.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+
+class TaskTile extends StatelessWidget {
+  final Task task;
+  final VoidCallback onChanged;
+
+  const TaskTile({Key? key, required this.task, required this.onChanged}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        task.title,
+        style: TextStyle(
+          decoration: task.isDone ? TextDecoration.lineThrough : null,
+        ),
+      ),
+      trailing: Checkbox(
+        value: task.isDone,
+        onChanged: (_) => onChanged(),
+      ),
+    );
+  }
+}

--- a/my_todo_app/pubspec.yaml
+++ b/my_todo_app/pubspec.yaml
@@ -1,0 +1,20 @@
+name: my_todo_app
+description: A simple Flutter to-do application
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/my_todo_app/test/task_model_test.dart
+++ b/my_todo_app/test/task_model_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_todo_app/models/task.dart';
+
+void main() {
+  test('toggleDone switches task state', () {
+    final task = Task(title: 'Test');
+    expect(task.isDone, isFalse);
+    task.toggleDone();
+    expect(task.isDone, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- set up `my_todo_app` directory with Flutter skeleton
- add basic model, UI, and service placeholders
- include initial test file

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685196a2dd04832ba27dd9c4934a9373