### PR TITLE
Add example tasks and swipe move functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.1.1] - Unreleased
+- Added default example tasks on startup.
+- Introduced two pages (Today and Tomorrow) with swipe/drag to move tasks to the next page.
+- Added changelog file.

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -9,57 +9,113 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> {
-  final List<Task> _tasks = [];
+class _HomePageState extends State<HomePage>
+    with SingleTickerProviderStateMixin {
+  final List<Task> _todayTasks = [
+    Task(title: 'Get milk'),
+    Task(title: 'Go to the car shop to get my carburator fixed'),
+    Task(title: '@myself remember to do sports & drink water'),
+  ];
+  final List<Task> _tomorrowTasks = [];
+
+  late final TabController _tabController;
   final TextEditingController _controller = TextEditingController();
 
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
   void _addTask(String title) {
+    if (title.trim().isEmpty) return;
     setState(() {
-      _tasks.add(Task(title: title));
+      if (_tabController.index == 0) {
+        _todayTasks.add(Task(title: title));
+      } else {
+        _tomorrowTasks.add(Task(title: title));
+      }
     });
     _controller.clear();
+  }
+
+  void _moveTaskToNextPage(int index) {
+    setState(() {
+      if (_tabController.index == 0 && index < _todayTasks.length) {
+        final task = _todayTasks.removeAt(index);
+        _tomorrowTasks.add(task);
+      } else if (_tabController.index == 1 && index < _tomorrowTasks.length) {
+        _tomorrowTasks.removeAt(index);
+      }
+    });
+  }
+
+  Widget _buildTaskList(List<Task> tasks) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  decoration: const InputDecoration(labelText: 'Add task'),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: () => _addTask(_controller.text),
+              )
+            ],
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: tasks.length,
+            itemBuilder: (context, index) {
+              final task = tasks[index];
+              return Dismissible(
+                key: ValueKey('${task.title}-$index-${_tabController.index}'),
+                background: Container(
+                  color: Colors.greenAccent.withOpacity(0.5),
+                ),
+                onDismissed: (_) => _moveTaskToNextPage(index),
+                child: TaskTile(
+                  task: task,
+                  onChanged: () => setState(task.toggleDone),
+                  onSwiped: () => _moveTaskToNextPage(index),
+                ),
+              );
+            },
+          ),
+        )
+      ],
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Best Todo 2')),
-      body: Column(
+      appBar: AppBar(
+        title: const Text('Best Todo 2'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [Tab(text: 'Today'), Tab(text: 'Tomorrow')],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
         children: [
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _controller,
-                    decoration: const InputDecoration(labelText: 'Add task'),
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.add),
-                  onPressed: () => _addTask(_controller.text),
-                )
-              ],
-            ),
-          ),
-          Expanded(
-            child: ListView.builder(
-              itemCount: _tasks.length,
-              itemBuilder: (context, index) {
-                final task = _tasks[index];
-                return Dismissible(
-                  key: ValueKey('${task.title}-$index'),
-                  background: Container(color: Colors.greenAccent.withOpacity(0.5)),
-                  onDismissed: (_) => setState(task.toggleDone),
-                  child: TaskTile(
-                    task: task,
-                    onChanged: () => setState(task.toggleDone),
-                  ),
-                );
-              },
-            ),
-          )
+          _buildTaskList(_todayTasks),
+          _buildTaskList(_tomorrowTasks),
         ],
       ),
     );

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -4,8 +4,14 @@ import '../models/task.dart';
 class TaskTile extends StatelessWidget {
   final Task task;
   final VoidCallback onChanged;
+  final VoidCallback onSwiped;
 
-  const TaskTile({Key? key, required this.task, required this.onChanged}) : super(key: key);
+  const TaskTile({
+    Key? key,
+    required this.task,
+    required this.onChanged,
+    required this.onSwiped,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -22,8 +28,8 @@ class TaskTile extends StatelessWidget {
       ),
       trailing: IconButton(
         icon: const Icon(Icons.swipe),
-        tooltip: 'Simulate swipe',
-        onPressed: onChanged,
+        tooltip: 'Move to next page',
+        onPressed: onSwiped,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add CHANGELOG.md with recent changes
- start app with three example tasks
- add TabBar with Today and Tomorrow lists
- move task to next page on swipe/dismiss
- update TaskTile for swipe callback

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541ebfbdbc832b9cedbfa8792d462b