### PR TITLE
Add dev/prod config and navigation

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,0 +1,4 @@
+class Config {
+  static const bool isProduction = bool.fromEnvironment('dart.vm.product');
+  static const bool isDev = !isProduction;
+}

--- a/lib/ui/about_page.dart
+++ b/lib/ui/about_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class AboutPage extends StatelessWidget {
+  const AboutPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('About')),
+      body: const Center(
+        child: Text('Best Todo 2\nVersion 0.1.0'),
+      ),
+    );
+  }
+}

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../models/task.dart';
+import '../config.dart';
+import 'about_page.dart';
+import 'settings_page.dart';
 import 'task_tile.dart';
 
 class HomePage extends StatefulWidget {
@@ -98,6 +101,42 @@ class _HomePageState extends State<HomePage>
     });
   }
 
+  void _advanceDay() {
+    setState(() {
+      final temp = List<Task>.from(_todayTasks);
+      _todayTasks
+        ..clear()
+        ..addAll(_tomorrowTasks);
+      _tomorrowTasks
+        ..clear()
+        ..addAll(_dayAfterTasks);
+      _dayAfterTasks
+        ..clear()
+        ..addAll(_nextWeekTasks);
+      _nextWeekTasks
+        ..clear()
+        ..addAll(temp);
+    });
+  }
+
+  void _rewindDay() {
+    setState(() {
+      final temp = List<Task>.from(_nextWeekTasks);
+      _nextWeekTasks
+        ..clear()
+        ..addAll(_dayAfterTasks);
+      _dayAfterTasks
+        ..clear()
+        ..addAll(_tomorrowTasks);
+      _tomorrowTasks
+        ..clear()
+        ..addAll(_todayTasks);
+      _todayTasks
+        ..clear()
+        ..addAll(temp);
+    });
+  }
+
   Widget _buildTaskList(List<Task> tasks, int pageIndex) {
     return Column(
       children: [
@@ -145,8 +184,51 @@ class _HomePageState extends State<HomePage>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            const DrawerHeader(
+              child: Text('Menu'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.info),
+              title: const Text('About'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AboutPage()),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Settings'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const SettingsPage()),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
       appBar: AppBar(
         title: const Text('Best Todo 2'),
+        actions: Config.isDev
+            ? [
+                IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  onPressed: _rewindDay,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.arrow_forward),
+                  onPressed: _advanceDay,
+                ),
+              ]
+            : null,
         bottom: TabBar(
           controller: _tabController,
           tabs: const [

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: const Center(
+        child: Text('Settings go here'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a config file to detect dev mode
- create About and Settings pages
- add a drawer menu linking to the new pages
- show date shift arrows in dev mode

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558bbdc784832bbe4fca473d6c7465