### PR TITLE
Implement Android swipe gesture and reduce checkbox spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Fundamentals
 1. less than 1 second cold startup
-2. the absolute minimum of clicks/steps to perform any action
+2. it must not be possible in less clicks/steps
 3. open source
 
 ## 🚀 MVP Features

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 📝 Swipe-first, ultra-fast to-do app built with Flutter. Tasks default to today. Move with gestures. Notes, labels, and smart rescheduling.
 
+## Fundamentals
+1. less than 1 second cold startup
+2. the absolute minimum of clicks/steps to perform any action
+3. open source
+
 ## 🚀 MVP Features
 - Add task: description, note, labels
 - Tasks default to today

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -20,4 +20,8 @@ class Config {
     'Day After Tomorrow',
     'Next Week',
   ];
+
+  /// If true, swipe left deletes a task and swipe right shows options.
+  /// Otherwise the directions are reversed.
+  static bool swipeLeftDelete = true;
 }

--- a/lib/ui/deleted_items_page.dart
+++ b/lib/ui/deleted_items_page.dart
@@ -4,7 +4,12 @@ import 'task_detail_page.dart';
 
 class DeletedItemsPage extends StatelessWidget {
   final List<Task> items;
-  const DeletedItemsPage({Key? key, required this.items}) : super(key: key);
+  final void Function(Task task) onRestore;
+  const DeletedItemsPage({
+    Key? key,
+    required this.items,
+    required this.onRestore,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -15,6 +20,11 @@ class DeletedItemsPage extends StatelessWidget {
         itemBuilder: (context, index) {
           final task = items[index];
           return ListTile(
+            leading: IconButton(
+              icon: const Icon(Icons.restore),
+              tooltip: 'Restore',
+              onPressed: () => onRestore(task),
+            ),
             title: Text(task.title),
             subtitle: task.description.isNotEmpty ? Text(task.description) : null,
             onTap: () {

--- a/lib/ui/deleted_items_page.dart
+++ b/lib/ui/deleted_items_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+
+class DeletedItemsPage extends StatelessWidget {
+  final List<Task> items;
+  const DeletedItemsPage({Key? key, required this.items}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Deleted Items')),
+      body: ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final task = items[index];
+          return ListTile(
+            title: Text(task.title),
+            subtitle: task.description.isNotEmpty ? Text(task.description) : null,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/deleted_items_page.dart
+++ b/lib/ui/deleted_items_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/task.dart';
+import 'task_detail_page.dart';
 
 class DeletedItemsPage extends StatelessWidget {
   final List<Task> items;
@@ -16,6 +17,13 @@ class DeletedItemsPage extends StatelessWidget {
           return ListTile(
             title: Text(task.title),
             subtitle: task.description.isNotEmpty ? Text(task.description) : null,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => TaskDetailPage(task: task),
+                ),
+              );
+            },
           );
         },
       ),

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -199,6 +199,7 @@ class _HomePageState extends State<HomePage>
                 task: task,
                 onChanged: () => setState(task.toggleDone),
                 onMove: (dest) => _moveTask(pageIndex, index, dest),
+                onMoveNext: () => _moveTaskToNextPage(pageIndex, index),
                 onDelete: () => _deleteTask(pageIndex, index),
                 showSwipeButton: !isAndroid,
                 swipeLeftDelete: Config.swipeLeftDelete,

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -138,6 +138,10 @@ class _HomePageState extends State<HomePage>
     });
   }
 
+  void _updateSettings() {
+    setState(() {});
+  }
+
   /// Change the current virtual date by the given number of days.
   /// When moving forward, overdue tasks remain visible in the Today tab.
   void _changeDate(int delta) {
@@ -197,6 +201,7 @@ class _HomePageState extends State<HomePage>
                 onMove: (dest) => _moveTask(pageIndex, index, dest),
                 onDelete: () => _deleteTask(pageIndex, index),
                 showSwipeButton: !isAndroid,
+                swipeLeftDelete: Config.swipeLeftDelete,
               );
               return isAndroid
                   ? tile
@@ -241,7 +246,11 @@ class _HomePageState extends State<HomePage>
               onTap: () {
                 Navigator.pop(context);
                 Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const SettingsPage()),
+                  MaterialPageRoute(
+                    builder: (_) => SettingsPage(
+                      onSettingsChanged: _updateSettings,
+                    ),
+                  ),
                 );
               },
             ),

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -141,18 +141,23 @@ class _HomePageState extends State<HomePage>
             itemCount: tasks.length,
             itemBuilder: (context, index) {
               final task = tasks[index];
-              return Dismissible(
-                key: ValueKey('${task.title}-$index-$pageIndex'),
-                background: Container(
-                  color: Colors.greenAccent.withOpacity(0.5),
-                ),
-                onDismissed: (_) => _moveTaskToNextPage(pageIndex, index),
-                child: TaskTile(
-                  task: task,
-                  onChanged: () => setState(task.toggleDone),
-                  onMove: (dest) => _moveTask(pageIndex, index, dest),
-                ),
+              final isAndroid = Theme.of(context).platform == TargetPlatform.android;
+              final tile = TaskTile(
+                task: task,
+                onChanged: () => setState(task.toggleDone),
+                onMove: (dest) => _moveTask(pageIndex, index, dest),
+                showSwipeButton: !isAndroid,
               );
+              return isAndroid
+                  ? tile
+                  : Dismissible(
+                      key: ValueKey('${task.title}-$index-$pageIndex'),
+                      background: Container(
+                        color: Colors.greenAccent.withOpacity(0.5),
+                      ),
+                      onDismissed: (_) => _moveTaskToNextPage(pageIndex, index),
+                      child: tile,
+                    );
             },
           ),
         )

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -131,6 +131,13 @@ class _HomePageState extends State<HomePage>
       );
   }
 
+  void _restoreTask(Task task) {
+    setState(() {
+      _deletedTasks.remove(task);
+      _tasks.add(task);
+    });
+  }
+
   /// Change the current virtual date by the given number of days.
   /// When moving forward, overdue tasks remain visible in the Today tab.
   void _changeDate(int delta) {
@@ -245,7 +252,10 @@ class _HomePageState extends State<HomePage>
                 Navigator.pop(context);
                 Navigator.of(context).push(
                   MaterialPageRoute(
-                    builder: (_) => DeletedItemsPage(items: _deletedTasks),
+                    builder: (_) => DeletedItemsPage(
+                      items: _deletedTasks,
+                      onRestore: _restoreTask,
+                    ),
                   ),
                 );
               },

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -4,6 +4,7 @@ import '../config.dart';
 import 'task_tile.dart';
 import 'about_page.dart';
 import 'settings_page.dart';
+import 'deleted_items_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -21,6 +22,7 @@ class _HomePageState extends State<HomePage>
   /// All tasks in the app. Tasks are assigned a dueDate when created and
   /// filtered into the appropriate lists based on [_currentDate].
   final List<Task> _tasks = [];
+  final List<Task> _deletedTasks = [];
 
   late final TabController _tabController;
   final TextEditingController _controller = TextEditingController();
@@ -89,6 +91,19 @@ class _HomePageState extends State<HomePage>
     });
   }
 
+  void _deleteTask(int pageIndex, int index) {
+    setState(() {
+      final tasks = _tasksForTab(pageIndex);
+      if (index >= tasks.length) return;
+      final task = tasks[index];
+      _tasks.remove(task);
+      _deletedTasks.insert(0, task);
+      if (_deletedTasks.length > 100) {
+        _deletedTasks.removeLast();
+      }
+    });
+  }
+
   /// Change the current virtual date by the given number of days.
   /// When moving forward, overdue tasks remain visible in the Today tab.
   void _changeDate(int delta) {
@@ -146,6 +161,7 @@ class _HomePageState extends State<HomePage>
                 task: task,
                 onChanged: () => setState(task.toggleDone),
                 onMove: (dest) => _moveTask(pageIndex, index, dest),
+                onDelete: () => _deleteTask(pageIndex, index),
                 showSwipeButton: !isAndroid,
               );
               return isAndroid
@@ -192,6 +208,18 @@ class _HomePageState extends State<HomePage>
                 Navigator.pop(context);
                 Navigator.of(context).push(
                   MaterialPageRoute(builder: (_) => const SettingsPage()),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.delete),
+              title: const Text('Deleted Items'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => DeletedItemsPage(items: _deletedTasks),
+                  ),
                 );
               },
             ),

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import '../config.dart';
 
 class SettingsPage extends StatefulWidget {
-  const SettingsPage({Key? key}) : super(key: key);
+  final VoidCallback? onSettingsChanged;
+  const SettingsPage({Key? key, this.onSettingsChanged}) : super(key: key);
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -9,15 +11,29 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   bool _notifications = false;
+  bool _swipeLeftDelete = Config.swipeLeftDelete;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: SwitchListTile(
-        title: const Text('Enable notifications'),
-        value: _notifications,
-        onChanged: (val) => setState(() => _notifications = val),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Enable notifications'),
+            value: _notifications,
+            onChanged: (val) => setState(() => _notifications = val),
+          ),
+          SwitchListTile(
+            title: const Text('Swipe left to delete'),
+            value: _swipeLeftDelete,
+            onChanged: (val) {
+              setState(() => _swipeLeftDelete = val);
+              Config.swipeLeftDelete = val;
+              widget.onSettingsChanged?.call();
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/task_detail_page.dart
+++ b/lib/ui/task_detail_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+
+class TaskDetailPage extends StatelessWidget {
+  final Task task;
+  const TaskDetailPage({Key? key, required this.task}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Task Details')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(task.title, style: Theme.of(context).textTheme.headline6),
+            if (task.description.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(task.description),
+            ],
+            if (task.note.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text('Note: ${task.note}'),
+            ],
+            if (task.label.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text('Label: ${task.label}'),
+            ],
+            if (task.dueDate != null) ...[
+              const SizedBox(height: 8),
+              Text('Due: ${task.dueDate!.toLocal().toString().split(' ')[0]}'),
+            ],
+            const SizedBox(height: 8),
+            Text('Completed: ${task.isDone ? 'Yes' : 'No'}'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/task_detail_page.dart
+++ b/lib/ui/task_detail_page.dart
@@ -14,7 +14,10 @@ class TaskDetailPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(task.title, style: Theme.of(context).textTheme.headline6),
+            Text(
+              task.title,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
             if (task.description.isNotEmpty) ...[
               const SizedBox(height: 8),
               Text(task.description),

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -10,6 +10,7 @@ class TaskTile extends StatefulWidget {
   final void Function(int destination) onMove;
   final VoidCallback onDelete;
   final bool showSwipeButton;
+  final bool swipeLeftDelete;
 
   const TaskTile({
     Key? key,
@@ -18,6 +19,7 @@ class TaskTile extends StatefulWidget {
     required this.onMove,
     required this.onDelete,
     this.showSwipeButton = true,
+    this.swipeLeftDelete = true,
   }) : super(key: key);
 
   @override
@@ -207,10 +209,18 @@ class _TaskTileState extends State<TaskTile>
         behavior: HitTestBehavior.opaque,
         onHorizontalDragEnd: (details) {
           final velocity = details.primaryVelocity ?? 0;
-          if (velocity > 0) {
-            _startOptions();
-          } else if (velocity < 0) {
-            widget.onDelete();
+          if (widget.swipeLeftDelete) {
+            if (velocity > 0) {
+              _startOptions();
+            } else if (velocity < 0) {
+              widget.onDelete();
+            }
+          } else {
+            if (velocity > 0) {
+              widget.onDelete();
+            } else if (velocity < 0) {
+              _startOptions();
+            }
           }
         },
         child: content,

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -8,6 +8,7 @@ class TaskTile extends StatefulWidget {
   final Task task;
   final VoidCallback onChanged;
   final void Function(int destination) onMove;
+  final VoidCallback onMoveNext;
   final VoidCallback onDelete;
   final bool showSwipeButton;
   final bool swipeLeftDelete;
@@ -17,6 +18,7 @@ class TaskTile extends StatefulWidget {
     required this.task,
     required this.onChanged,
     required this.onMove,
+    required this.onMoveNext,
     required this.onDelete,
     this.showSwipeButton = true,
     this.swipeLeftDelete = true,
@@ -211,7 +213,7 @@ class _TaskTileState extends State<TaskTile>
           final velocity = details.primaryVelocity ?? 0;
           if (widget.swipeLeftDelete) {
             if (velocity > 0) {
-              _startOptions();
+              widget.onMoveNext();
             } else if (velocity < 0) {
               widget.onDelete();
             }
@@ -219,7 +221,7 @@ class _TaskTileState extends State<TaskTile>
             if (velocity > 0) {
               widget.onDelete();
             } else if (velocity < 0) {
-              _startOptions();
+              widget.onMoveNext();
             }
           }
         },

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -207,9 +207,9 @@ class _TaskTileState extends State<TaskTile>
         behavior: HitTestBehavior.opaque,
         onHorizontalDragEnd: (details) {
           final velocity = details.primaryVelocity ?? 0;
-          if (velocity < 0) {
+          if (velocity > 0) {
             _startOptions();
-          } else if (velocity > 0) {
+          } else if (velocity < 0) {
             widget.onDelete();
           }
         },

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -207,9 +207,9 @@ class _TaskTileState extends State<TaskTile>
         behavior: HitTestBehavior.opaque,
         onHorizontalDragEnd: (details) {
           final velocity = details.primaryVelocity ?? 0;
-          if (velocity > 0) {
+          if (velocity < 0) {
             _startOptions();
-          } else if (velocity < 0) {
+          } else if (velocity > 0) {
             widget.onDelete();
           }
         },

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -59,7 +59,7 @@ class _TaskTileState extends State<TaskTile>
     _progressController.forward();
     _timer = Timer(Duration(seconds: Config.defaultDelaySeconds), () {
       if (mounted && _showOptions) {
-        widget.onMove(1); // default to tomorrow
+        widget.onMoveNext();
         _progressController.stop();
         setState(() => _showOptions = false);
       }
@@ -213,7 +213,7 @@ class _TaskTileState extends State<TaskTile>
           final velocity = details.primaryVelocity ?? 0;
           if (widget.swipeLeftDelete) {
             if (velocity > 0) {
-              widget.onMoveNext();
+              _startOptions();
             } else if (velocity < 0) {
               widget.onDelete();
             }
@@ -221,7 +221,7 @@ class _TaskTileState extends State<TaskTile>
             if (velocity > 0) {
               widget.onDelete();
             } else if (velocity < 0) {
-              widget.onMoveNext();
+              _startOptions();
             }
           }
         },

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -8,6 +8,7 @@ class TaskTile extends StatefulWidget {
   final Task task;
   final VoidCallback onChanged;
   final void Function(int destination) onMove;
+  final VoidCallback onDelete;
   final bool showSwipeButton;
 
   const TaskTile({
@@ -15,6 +16,7 @@ class TaskTile extends StatefulWidget {
     required this.task,
     required this.onChanged,
     required this.onMove,
+    required this.onDelete,
     this.showSwipeButton = true,
   }) : super(key: key);
 
@@ -203,7 +205,14 @@ class _TaskTileState extends State<TaskTile>
     if (isAndroid) {
       content = GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onHorizontalDragStart: (_) => _startOptions(),
+        onHorizontalDragEnd: (details) {
+          final velocity = details.primaryVelocity ?? 0;
+          if (velocity > 0) {
+            _startOptions();
+          } else if (velocity < 0) {
+            widget.onDelete();
+          }
+        },
         child: content,
       );
     }

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 import '../models/task.dart';
 import '../config.dart';
@@ -7,12 +8,14 @@ class TaskTile extends StatefulWidget {
   final Task task;
   final VoidCallback onChanged;
   final void Function(int destination) onMove;
+  final bool showSwipeButton;
 
   const TaskTile({
     Key? key,
     required this.task,
     required this.onChanged,
     required this.onMove,
+    this.showSwipeButton = true,
   }) : super(key: key);
 
   @override
@@ -81,11 +84,15 @@ class _TaskTileState extends State<TaskTile>
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
+    final isAndroid = defaultTargetPlatform == TargetPlatform.android;
+    Widget content = InkWell(
       onTap: _toggleExpanded,
       child: Column(
         children: [
           ListTile(
+            contentPadding:
+                isAndroid ? EdgeInsets.zero : const EdgeInsets.symmetric(horizontal: 16.0),
+            minLeadingWidth: isAndroid ? 0 : null,
             leading: Checkbox(
               value: widget.task.isDone,
               onChanged: (_) => setState(() => widget.onChanged()),
@@ -129,11 +136,13 @@ class _TaskTileState extends State<TaskTile>
                       ),
                     ],
                   )
-                : IconButton(
-                    icon: const Icon(Icons.swipe),
-                    tooltip: 'Reschedule',
-                    onPressed: _startOptions,
-                  ),
+                : (widget.showSwipeButton
+                    ? IconButton(
+                        icon: const Icon(Icons.swipe),
+                        tooltip: 'Reschedule',
+                        onPressed: _startOptions,
+                      )
+                    : null),
           ),
           if (_expanded)
             Padding(
@@ -190,5 +199,15 @@ class _TaskTileState extends State<TaskTile>
         ],
       ),
     );
+
+    if (isAndroid) {
+      content = GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: (_) => _startOptions(),
+        child: content,
+      );
+    }
+
+    return content;
   }
 }


### PR DESCRIPTION
## Summary
- hide reschedule button on Android by default
- trigger reschedule options with a horizontal swipe on Android
- reduce checkbox whitespace on Android

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685933a1c328832baf4db9c5bfbf1a7a