### PR TITLE
Add configurable swipe directions

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -20,4 +20,8 @@ class Config {
     'Day After Tomorrow',
     'Next Week',
   ];
+
+  /// If true, swipe left deletes a task and swipe right shows options.
+  /// Otherwise the directions are reversed.
+  static bool swipeLeftDelete = true;
 }

--- a/lib/ui/deleted_items_page.dart
+++ b/lib/ui/deleted_items_page.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+import 'task_detail_page.dart';
+
+class DeletedItemsPage extends StatelessWidget {
+  final List<Task> items;
+  final void Function(Task task) onRestore;
+  const DeletedItemsPage({
+    Key? key,
+    required this.items,
+    required this.onRestore,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Deleted Items')),
+      body: ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final task = items[index];
+          return ListTile(
+            leading: IconButton(
+              icon: const Icon(Icons.restore),
+              tooltip: 'Restore',
+              onPressed: () => onRestore(task),
+            ),
+            title: Text(task.title),
+            subtitle: task.description.isNotEmpty ? Text(task.description) : null,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => TaskDetailPage(task: task),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import '../config.dart';
 
 class SettingsPage extends StatefulWidget {
-  const SettingsPage({Key? key}) : super(key: key);
+  final VoidCallback? onSettingsChanged;
+  const SettingsPage({Key? key, this.onSettingsChanged}) : super(key: key);
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -9,15 +11,29 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   bool _notifications = false;
+  bool _swipeLeftDelete = Config.swipeLeftDelete;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: SwitchListTile(
-        title: const Text('Enable notifications'),
-        value: _notifications,
-        onChanged: (val) => setState(() => _notifications = val),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Enable notifications'),
+            value: _notifications,
+            onChanged: (val) => setState(() => _notifications = val),
+          ),
+          SwitchListTile(
+            title: const Text('Swipe left to delete'),
+            value: _swipeLeftDelete,
+            onChanged: (val) {
+              setState(() => _swipeLeftDelete = val);
+              Config.swipeLeftDelete = val;
+              widget.onSettingsChanged?.call();
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/task_detail_page.dart
+++ b/lib/ui/task_detail_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+
+class TaskDetailPage extends StatelessWidget {
+  final Task task;
+  const TaskDetailPage({Key? key, required this.task}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Task Details')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              task.title,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            if (task.description.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(task.description),
+            ],
+            if (task.note.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text('Note: ${task.note}'),
+            ],
+            if (task.label.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text('Label: ${task.label}'),
+            ],
+            if (task.dueDate != null) ...[
+              const SizedBox(height: 8),
+              Text('Due: ${task.dueDate!.toLocal().toString().split(' ')[0]}'),
+            ],
+            const SizedBox(height: 8),
+            Text('Completed: ${task.isDone ? 'Yes' : 'No'}'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 import '../models/task.dart';
 import '../config.dart';
@@ -7,12 +8,20 @@ class TaskTile extends StatefulWidget {
   final Task task;
   final VoidCallback onChanged;
   final void Function(int destination) onMove;
+  final VoidCallback onMoveNext;
+  final VoidCallback onDelete;
+  final bool showSwipeButton;
+  final bool swipeLeftDelete;
 
   const TaskTile({
     Key? key,
     required this.task,
     required this.onChanged,
     required this.onMove,
+    required this.onMoveNext,
+    required this.onDelete,
+    this.showSwipeButton = true,
+    this.swipeLeftDelete = true,
   }) : super(key: key);
 
   @override
@@ -81,11 +90,15 @@ class _TaskTileState extends State<TaskTile>
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
+    final isAndroid = defaultTargetPlatform == TargetPlatform.android;
+    Widget content = InkWell(
       onTap: _toggleExpanded,
       child: Column(
         children: [
           ListTile(
+            contentPadding:
+                isAndroid ? EdgeInsets.zero : const EdgeInsets.symmetric(horizontal: 16.0),
+            minLeadingWidth: isAndroid ? 0 : null,
             leading: Checkbox(
               value: widget.task.isDone,
               onChanged: (_) => setState(() => widget.onChanged()),
@@ -129,11 +142,13 @@ class _TaskTileState extends State<TaskTile>
                       ),
                     ],
                   )
-                : IconButton(
-                    icon: const Icon(Icons.swipe),
-                    tooltip: 'Reschedule',
-                    onPressed: _startOptions,
-                  ),
+                : (widget.showSwipeButton
+                    ? IconButton(
+                        icon: const Icon(Icons.swipe),
+                        tooltip: 'Reschedule',
+                        onPressed: _startOptions,
+                      )
+                    : null),
           ),
           if (_expanded)
             Padding(
@@ -190,5 +205,30 @@ class _TaskTileState extends State<TaskTile>
         ],
       ),
     );
+
+    if (isAndroid) {
+      content = GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragEnd: (details) {
+          final velocity = details.primaryVelocity ?? 0;
+          if (widget.swipeLeftDelete) {
+            if (velocity > 0) {
+              widget.onMoveNext();
+            } else if (velocity < 0) {
+              widget.onDelete();
+            }
+          } else {
+            if (velocity > 0) {
+              widget.onDelete();
+            } else if (velocity < 0) {
+              widget.onMoveNext();
+            }
+          }
+        },
+        child: content,
+      );
+    }
+
+    return content;
   }
 }


### PR DESCRIPTION
## Summary
- add `Config.swipeLeftDelete` to store user preference for swipe directions
- let SettingsPage toggle the swipe directions via `Swipe left to delete`
- use the new setting in TaskTile gesture handling
- update HomePage to rebuild when settings change and pass preference to each TaskTile
- make swiping move tasks to the next list on Android

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685933a1c328832baf4db9c5bfbf1a7a