### PR TITLE
Improve swipe options and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,12 @@
   Day After Tomorrow, or Next Week (defaulting to Tomorrow if none selected).
 - Fixed swipe button logic so tasks move only after the 2-second delay if no
   option is tapped.
+- Fixed headline text style in the task detail page.
+- Added expandable task editing with description, notes and labels.
+- Added settings page with configurable swipe direction.
+- Added drawer navigation with About, Settings and Deleted Items pages.
+- Added undoable delete with snackbar and Deleted Items restore list.
+- Added task detail view when tapping items in Deleted list.
+- Added dev mode date navigation and automatic cleanup of completed tasks.
+- Reschedule options now appear when swiping tasks and the swipe button is hidden on Android.
+- Swipe gestures now move tasks to the next list by default and wrap from Next Week back to Today.

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -66,19 +66,15 @@ class _HomePageState extends State<HomePage>
 
   void _moveTaskToNextPage(int pageIndex, int index) {
     final tasks = _tasksForTab(pageIndex);
-    int? destination;
-    if (pageIndex == 0) destination = 1;
-    if (pageIndex == 1) destination = 2;
-    if (pageIndex == 2) destination = 3;
+    int destination = pageIndex + 1;
+    if (destination >= Config.tabs.length) {
+      destination = 0;
+    }
     setState(() {
       if (index >= tasks.length) return;
       final task = tasks[index];
-      if (destination != null) {
-        task.dueDate =
-            _currentDate.add(Duration(days: _offsetDays[destination]));
-      } else {
-        _tasks.remove(task);
-      }
+      task.dueDate =
+          _currentDate.add(Duration(days: _offsetDays[destination]));
     });
   }
 
@@ -201,6 +197,7 @@ class _HomePageState extends State<HomePage>
                 onMove: (dest) => _moveTask(pageIndex, index, dest),
                 onMoveNext: () => _moveTaskToNextPage(pageIndex, index),
                 onDelete: () => _deleteTask(pageIndex, index),
+                pageIndex: pageIndex,
                 showSwipeButton: !isAndroid,
                 swipeLeftDelete: Config.swipeLeftDelete,
               );

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -10,6 +10,7 @@ class TaskTile extends StatefulWidget {
   final void Function(int destination) onMove;
   final VoidCallback onMoveNext;
   final VoidCallback onDelete;
+  final int pageIndex;
   final bool showSwipeButton;
   final bool swipeLeftDelete;
 
@@ -20,6 +21,7 @@ class TaskTile extends StatefulWidget {
     required this.onMove,
     required this.onMoveNext,
     required this.onDelete,
+    required this.pageIndex,
     this.showSwipeButton = true,
     this.swipeLeftDelete = true,
   }) : super(key: key);
@@ -38,6 +40,7 @@ class _TaskTileState extends State<TaskTile>
   late final TextEditingController _descController;
   late final TextEditingController _noteController;
   late final TextEditingController _labelController;
+  late final List<int> _destinations;
 
   @override
   void initState() {
@@ -50,6 +53,8 @@ class _TaskTileState extends State<TaskTile>
       vsync: this,
       duration: Duration(seconds: Config.defaultDelaySeconds),
     );
+    _destinations = List<int>.generate(Config.tabs.length, (i) => i)
+      ..remove(widget.pageIndex);
   }
 
   void _startOptions() {
@@ -116,18 +121,11 @@ class _TaskTileState extends State<TaskTile>
                       Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          TextButton(
-                            onPressed: () => _select(1),
-                            child: const Text('Tomorrow'),
-                          ),
-                          TextButton(
-                            onPressed: () => _select(2),
-                            child: const Text('Day After Tomorrow'),
-                          ),
-                          TextButton(
-                            onPressed: () => _select(3),
-                            child: const Text('Next Week'),
-                          ),
+                          for (var dest in _destinations)
+                            TextButton(
+                              onPressed: () => _select(dest),
+                              child: Text(Config.tabs[dest]),
+                            ),
                         ],
                       ),
                       const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- update changelog with current features and bug fixes
- cycle swipes from last list back to Today
- show the three other lists when rescheduling a task

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859604d9914832b9c9e0d4fab7d0353