### PR TITLE
Add auto version bump & changelog page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [0.1.2] - Unreleased
+## [0.1.3] - Unreleased
+
+## [0.1.2] - 2025-06-23
 - Added default example tasks on startup.
 - Introduced two pages (Today and Tomorrow) with swipe/drag to move tasks to the next page.
 - Added changelog file.

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -6,7 +6,7 @@ class Config {
   static const bool isDev = !bool.fromEnvironment('dart.vm.product');
 
   /// Current application version.
-  static const String version = '0.1.2';
+  static const String version = '0.1.3';
 
   static const List<String> initialTasks = [
     'Get milk',

--- a/lib/ui/changelog_page.dart
+++ b/lib/ui/changelog_page.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+class ChangelogPage extends StatelessWidget {
+  const ChangelogPage({Key? key}) : super(key: key);
+
+  Future<String> _loadChangelog() async {
+    return rootBundle.loadString('CHANGELOG.md');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Changelog')),
+      body: FutureBuilder<String>(
+        future: _loadChangelog(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return Markdown(data: snapshot.data!);
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -7,6 +7,7 @@ import 'task_tile.dart';
 import 'about_page.dart';
 import 'settings_page.dart';
 import 'deleted_items_page.dart';
+import 'changelog_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -271,6 +272,16 @@ class _HomePageState extends State<HomePage>
                       onSettingsChanged: _updateSettings,
                     ),
                   ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.history),
+              title: const Text('Changelog'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const ChangelogPage()),
                 );
               },
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: best_todo_2
 description: A simple Flutter to-do application
 publish_to: 'none'
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
@@ -12,6 +12,7 @@ dependencies:
 
   cupertino_icons: ^1.0.2
   path_provider: ^2.0.0
+  flutter_markdown: ^0.6.10
 
 dev_dependencies:
   flutter_test:
@@ -19,3 +20,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - CHANGELOG.md

--- a/tool/build.sh
+++ b/tool/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Bump version and run flutter build with given arguments.
+dart run tool/bump_version.dart
+flutter build "$@"

--- a/tool/bump_version.dart
+++ b/tool/bump_version.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+void main() {
+  final pubspecFile = File('pubspec.yaml');
+  if (!pubspecFile.existsSync()) {
+    stderr.writeln('pubspec.yaml not found');
+    exit(1);
+  }
+
+  // Read pubspec.yaml and extract current version
+  final pubspecLines = pubspecFile.readAsLinesSync();
+  final versionIndex = pubspecLines.indexWhere((l) => l.startsWith('version:'));
+  if (versionIndex == -1) {
+    stderr.writeln('version not found in pubspec.yaml');
+    exit(1);
+  }
+  final currentVersion = pubspecLines[versionIndex].split(':')[1].trim();
+  final parts = currentVersion.split('.');
+  if (parts.length != 3) {
+    stderr.writeln('version format invalid: $currentVersion');
+    exit(1);
+  }
+  final major = int.parse(parts[0]);
+  final minor = int.parse(parts[1]);
+  var patch = int.parse(parts[2]);
+  patch++;
+  final newVersion = '$major.$minor.$patch';
+
+  pubspecLines[versionIndex] = 'version: $newVersion';
+  pubspecFile.writeAsStringSync(pubspecLines.join('\n'));
+
+  // Update lib/config.dart version constant
+  final configFile = File('lib/config.dart');
+  if (configFile.existsSync()) {
+    final configContent = configFile.readAsStringSync();
+    final updated = configContent.replaceFirst(
+        RegExp("version = '[^']+'"), "version = '$newVersion'");
+    configFile.writeAsStringSync(updated);
+  }
+
+  // Update CHANGELOG
+  final changelogFile = File('CHANGELOG.md');
+  if (changelogFile.existsSync()) {
+    final lines = changelogFile.readAsLinesSync();
+    if (lines.length >= 2 && lines[1].contains('Unreleased')) {
+      final date = DateTime.now().toIso8601String().split('T').first;
+      lines[1] = lines[1].replaceFirst('Unreleased', date);
+    }
+    lines.insert(1, '## [$newVersion] - Unreleased');
+    lines.insert(2, '');
+    changelogFile.writeAsStringSync(lines.join('\n'));
+  }
+
+  stdout.writeln('Bumped version to $newVersion');
+}


### PR DESCRIPTION
## Summary
- auto-increment version script and build wrapper
- add changelog markdown viewer page
- link changelog from the drawer menu
- register changelog asset and add `flutter_markdown`
- bump version to 0.1.3 and update changelog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a221c1bc832ba34481fb24e5c0fc