### PR TITLE
Add dark mode setting

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -24,4 +24,7 @@ class Config {
   /// If true, swipe left deletes a task and swipe right shows options.
   /// Otherwise the directions are reversed.
   static bool swipeLeftDelete = true;
+
+  /// If true, the app uses a dark color scheme.
+  static bool darkMode = false;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,31 @@
 import 'package:flutter/material.dart';
 import 'ui/home_page.dart';
+import 'config.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
+
+  static _MyAppState? of(BuildContext context) =>
+      context.findAncestorStateOfType<_MyAppState>();
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  void updateTheme() => setState(() {});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Best Todo 2',
       theme: ThemeData(primarySwatch: Colors.blue),
+      darkTheme: ThemeData.dark(),
+      themeMode: Config.darkMode ? ThemeMode.dark : ThemeMode.light,
       home: const HomePage(),
     );
   }

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../config.dart';
+import '../main.dart';
 
 class SettingsPage extends StatefulWidget {
   final VoidCallback? onSettingsChanged;
@@ -12,6 +13,7 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   bool _notifications = false;
   bool _swipeLeftDelete = Config.swipeLeftDelete;
+  bool _darkMode = Config.darkMode;
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +25,16 @@ class _SettingsPageState extends State<SettingsPage> {
             title: const Text('Enable notifications'),
             value: _notifications,
             onChanged: (val) => setState(() => _notifications = val),
+          ),
+          SwitchListTile(
+            title: const Text('Dark mode'),
+            value: _darkMode,
+            onChanged: (val) {
+              setState(() => _darkMode = val);
+              Config.darkMode = val;
+              MyApp.of(context)?.updateTheme();
+              widget.onSettingsChanged?.call();
+            },
           ),
           SwitchListTile(
             title: const Text('Swipe left to delete'),


### PR DESCRIPTION
## Summary
- allow toggling dark mode in settings
- rebuild the app when the theme changes

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686387b44adc832b813b46a6f6e54618