### PR TITLE
Add language dropdown in settings

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 class Config {
   static const int defaultDelaySeconds = 5;
 
@@ -20,6 +22,20 @@ class Config {
     'Day After Tomorrow',
     'Next Week',
   ];
+
+  /// Supported locales for the app.
+  static const List<Locale> supportedLocales = [
+    Locale('en'),
+    Locale('es'),
+    Locale('fr'),
+  ];
+
+  /// Human readable names for the supported locales.
+  static const Map<String, String> localeNames = {
+    'en': 'English',
+    'es': 'Spanish',
+    'fr': 'French',
+  };
 
   /// If true, swipe left deletes a task and swipe right shows options.
   /// Otherwise the directions are reversed.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import '../config.dart';
+import 'package:flutter/foundation.dart';
+
+class AppLocalizations {
+  final Locale locale;
+  const AppLocalizations(this.locale);
+
+  static const Map<String, Map<String, dynamic>> _localizedValues = {
+    'en': {
+      'appTitle': 'Best Todo 2',
+      'menu': 'Menu',
+      'about': 'About',
+      'settings': 'Settings',
+      'changelog': 'Changelog',
+      'deletedItems': 'Deleted Items',
+      'addTask': 'Add task',
+      'notifications': 'Enable notifications',
+      'swipe': 'Swipe left to delete',
+      'language': 'Language',
+      'tabs': ['Today','Tomorrow','Day After Tomorrow','Next Week'],
+      'cancel': 'Cancel',
+      'taskDetails': 'Task Details',
+      'note': 'Note',
+      'label': 'Label',
+      'due': 'Due',
+      'completed': 'Completed',
+      'yes': 'Yes',
+      'no': 'No',
+      'reschedule': 'Reschedule',
+      'deleted': 'Deleted "{task}"',
+      'aboutBody': 'Best Todo 2 v{version}\nRunning in {mode} mode',
+      'restore': 'Restore',
+      'development': 'Development',
+      'production': 'Production',
+    },
+    'es': {
+      'appTitle': 'Mejor Tareas 2',
+      'menu': 'Men\u00fa',
+      'about': 'Acerca de',
+      'settings': 'Configuraci\u00f3n',
+      'changelog': 'Registro de cambios',
+      'deletedItems': 'Elementos eliminados',
+      'addTask': 'Agregar tarea',
+      'notifications': 'Habilitar notificaciones',
+      'swipe': 'Deslizar a la izquierda para eliminar',
+      'language': 'Idioma',
+      'tabs': ['Hoy','Ma\u00f1ana','Pasado ma\u00f1ana','Pr\u00f3xima semana'],
+      'cancel': 'Cancelar',
+      'taskDetails': 'Detalles de la tarea',
+      'note': 'Nota',
+      'label': 'Etiqueta',
+      'due': 'Vencimiento',
+      'completed': 'Completado',
+      'yes': 'Sí',
+      'reschedule': 'Reprogramar',
+      'no': 'No',
+      'deleted': 'Se elimin\u00f3 "{task}"',
+      'aboutBody': 'Best Todo 2 v{version}\nEjecut\u00e1ndose en modo {mode}',
+      'restore': 'Restaurar',
+      'development': 'Desarrollo',
+      'production': 'Producci\u00f3n',
+    },
+    'fr': {
+      'appTitle': 'Meilleur Todo 2',
+      'menu': 'Menu',
+      'about': '\u00c0 propos',
+      'settings': 'Param\u00e8tres',
+      'changelog': 'Journal des modifications',
+      'deletedItems': '\u00c9l\u00e9ments supprim\u00e9s',
+      'addTask': 'Ajouter une t\u00e2che',
+      'notifications': 'Activer les notifications',
+      'swipe': 'Glisser \u00e0 gauche pour supprimer',
+      'language': 'Langue',
+      'tabs': ['Aujourd\u2019hui','Demain','Apr\u00e8s-demain','La semaine prochaine'],
+      'cancel': 'Annuler',
+      'taskDetails': 'D\u00e9tails de la t\u00e2che',
+      'note': 'Note',
+      'label': '\u00c9tiquette',
+      'due': '\u00c9ch\u00e9ance',
+      'completed': 'Termin\u00e9',
+      'reschedule': 'Replanifier',
+      'yes': 'Oui',
+      'no': 'Non',
+      'deleted': 'Supprim\u00e9 "{task}"',
+      'aboutBody': 'Best Todo 2 v{version}\nEx\u00e9cut\u00e9 en mode {mode}',
+      'restore': 'Restaurer',
+      'development': 'D\u00e9veloppement',
+      'production': 'Production',
+    },
+  };
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  String _string(String key) {
+    final lang = locale.languageCode;
+    return (_localizedValues[lang] ?? _localizedValues['en'])![key] as String;
+  }
+
+  List<String> get tabs {
+    final lang = locale.languageCode;
+    return List<String>.from(
+      (_localizedValues[lang] ?? _localizedValues['en'])!['tabs'] ??
+          _localizedValues['en']!['tabs'],
+    );
+  }
+
+  String get appTitle => _string('appTitle');
+  String get menu => _string('menu');
+  String get about => _string('about');
+  String get settings => _string('settings');
+  String get changelog => _string('changelog');
+  String get deletedItems => _string('deletedItems');
+  String get addTask => _string('addTask');
+  String get enableNotifications => _string('notifications');
+  String get swipeLeftDelete => _string('swipe');
+  String get language => _string('language');
+  String get taskDetails => _string('taskDetails');
+  String get cancel => _string('cancel');
+  String get restore => _string('restore');
+  String get note => _string('note');
+  String get label => _string('label');
+  String get reschedule => _string('reschedule');
+  String get due => _string('due');
+  String get completed => _string('completed');
+  String get yes => _string('yes');
+  String get no => _string('no');
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return Config.supportedLocales
+        .any((l) => l.languageCode == locale.languageCode);
+  }
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture(AppLocalizations(locale));
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) => false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'ui/home_page.dart';
 import 'config.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'l10n/app_localizations.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,11 +31,16 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Best Todo 2',
+      onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
       theme: ThemeData(primarySwatch: Colors.blue),
       locale: _locale,
       supportedLocales: Config.supportedLocales,
-      localizationsDelegates: GlobalMaterialLocalizations.delegates,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       home: const HomePage(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,40 @@
 import 'package:flutter/material.dart';
 import 'ui/home_page.dart';
+import 'config.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+
+  static _MyAppState? of(BuildContext context) {
+    return context.findAncestorStateOfType<_MyAppState>();
+  }
+}
+
+class _MyAppState extends State<MyApp> {
+  Locale? _locale;
+
+  void setLocale(Locale locale) {
+    setState(() {
+      _locale = locale;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Best Todo 2',
       theme: ThemeData(primarySwatch: Colors.blue),
+      locale: _locale,
+      supportedLocales: Config.supportedLocales,
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       home: const HomePage(),
     );
   }

--- a/lib/ui/about_page.dart
+++ b/lib/ui/about_page.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
 import '../config.dart';
+import '../l10n/app_localizations.dart';
 
 class AboutPage extends StatelessWidget {
   const AboutPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final mode = Config.isDev ? 'Development' : 'Production';
+    final l10n = AppLocalizations.of(context);
+    final mode = Config.isDev ? l10n.development : l10n.production;
     return Scaffold(
-      appBar: AppBar(title: const Text('About')),
+      appBar: AppBar(title: Text(l10n.about)),
       body: Center(
         child: Text(
-          'Best Todo 2 v${Config.version}\nRunning in $mode mode',
+          l10n.aboutBody(Config.version, mode),
           textAlign: TextAlign.center,
         ),
       ),

--- a/lib/ui/changelog_page.dart
+++ b/lib/ui/changelog_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_markdown/flutter_markdown.dart';
+import '../l10n/app_localizations.dart';
 
 class ChangelogPage extends StatelessWidget {
   const ChangelogPage({Key? key}) : super(key: key);
@@ -11,8 +12,9 @@ class ChangelogPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Changelog')),
+      appBar: AppBar(title: Text(l10n.changelog)),
       body: FutureBuilder<String>(
         future: _loadChangelog(),
         builder: (context, snapshot) {

--- a/lib/ui/deleted_items_page.dart
+++ b/lib/ui/deleted_items_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/task.dart';
 import 'task_detail_page.dart';
+import '../l10n/app_localizations.dart';
 
 class DeletedItemsPage extends StatelessWidget {
   final List<Task> items;
@@ -13,8 +14,9 @@ class DeletedItemsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Deleted Items')),
+      appBar: AppBar(title: Text(l10n.deletedItems)),
       body: ListView.builder(
         itemCount: items.length,
         itemBuilder: (context, index) {
@@ -22,7 +24,7 @@ class DeletedItemsPage extends StatelessWidget {
           return ListTile(
             leading: IconButton(
               icon: const Icon(Icons.restore),
-              tooltip: 'Restore',
+              tooltip: l10n.restore,
               onPressed: () => onRestore(task),
             ),
             title: Text(task.title),

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -9,6 +9,7 @@ import 'settings_page.dart';
 import 'deleted_items_page.dart';
 import 'changelog_page.dart';
 import '../main.dart' show MyApp;
+import '../l10n/app_localizations.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -126,14 +127,15 @@ class _HomePageState extends State<HomePage>
       });
     });
 
+    final l10n = AppLocalizations.of(context);
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(
         SnackBar(
-          content: Text('Deleted "${task.title}"'),
+          content: Text(l10n.deleted(task.title)),
           duration: const Duration(seconds: Config.defaultDelaySeconds),
           action: SnackBarAction(
-            label: 'Cancel',
+            label: l10n.cancel,
             onPressed: () {
               timer.cancel();
               setState(() {
@@ -201,7 +203,9 @@ class _HomePageState extends State<HomePage>
               Expanded(
                 child: TextField(
                   controller: _controller,
-                  decoration: const InputDecoration(labelText: 'Add task'),
+                  decoration: InputDecoration(
+                    labelText: AppLocalizations.of(context).addTask,
+                  ),
                   onSubmitted: _addTask,
                 ),
               ),
@@ -254,13 +258,16 @@ class _HomePageState extends State<HomePage>
       drawer: Drawer(
         child: ListView(
           children: [
-            const DrawerHeader(
-              decoration: BoxDecoration(color: Colors.blue),
-              child: Text('Menu', style: TextStyle(color: Colors.white)),
+            DrawerHeader(
+              decoration: const BoxDecoration(color: Colors.blue),
+              child: Text(
+                AppLocalizations.of(context).menu,
+                style: const TextStyle(color: Colors.white),
+              ),
             ),
             ListTile(
               leading: const Icon(Icons.info),
-              title: const Text('About'),
+              title: Text(AppLocalizations.of(context).about),
               onTap: () {
                 Navigator.pop(context);
                 Navigator.of(context).push(
@@ -270,7 +277,7 @@ class _HomePageState extends State<HomePage>
             ),
             ListTile(
               leading: const Icon(Icons.settings),
-              title: const Text('Settings'),
+              title: Text(AppLocalizations.of(context).settings),
               onTap: () {
                 Navigator.pop(context);
                 Navigator.of(context).push(
@@ -285,7 +292,7 @@ class _HomePageState extends State<HomePage>
             ),
             ListTile(
               leading: const Icon(Icons.history),
-              title: const Text('Changelog'),
+              title: Text(AppLocalizations.of(context).changelog),
               onTap: () {
                 Navigator.pop(context);
                 Navigator.of(context).push(
@@ -295,7 +302,7 @@ class _HomePageState extends State<HomePage>
             ),
             ListTile(
               leading: const Icon(Icons.delete),
-              title: const Text('Deleted Items'),
+              title: Text(AppLocalizations.of(context).deletedItems),
               onTap: () {
                 Navigator.pop(context);
                 Navigator.of(context).push(
@@ -312,7 +319,7 @@ class _HomePageState extends State<HomePage>
         ),
       ),
       appBar: AppBar(
-        title: const Text('Best Todo 2'),
+        title: Text(AppLocalizations.of(context).appTitle),
         bottom: PreferredSize(
           preferredSize: Size.fromHeight(Config.isDev ? 72 : 48),
           child: Column(
@@ -337,7 +344,10 @@ class _HomePageState extends State<HomePage>
                 ),
               TabBar(
                 controller: _tabController,
-                tabs: Config.tabs.map((t) => Tab(text: t)).toList(),
+                tabs: AppLocalizations.of(context)
+                    .tabs
+                    .map((t) => Tab(text: t))
+                    .toList(),
               ),
             ],
           ),

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -8,6 +8,7 @@ import 'about_page.dart';
 import 'settings_page.dart';
 import 'deleted_items_page.dart';
 import 'changelog_page.dart';
+import '../main.dart' show MyApp;
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -158,6 +159,11 @@ class _HomePageState extends State<HomePage>
     setState(() {});
   }
 
+  void _setLocale(Locale locale) {
+    final state = MyApp.of(context);
+    state?.setLocale(locale);
+  }
+
   /// Change the current virtual date by the given number of days.
   /// When moving forward, overdue tasks remain visible in the Today tab.
   void _changeDate(int delta) {
@@ -271,6 +277,7 @@ class _HomePageState extends State<HomePage>
                   MaterialPageRoute(
                     builder: (_) => SettingsPage(
                       onSettingsChanged: _updateSettings,
+                      onLanguageChanged: _setLocale,
                     ),
                   ),
                 );

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -3,7 +3,9 @@ import '../config.dart';
 
 class SettingsPage extends StatefulWidget {
   final VoidCallback? onSettingsChanged;
-  const SettingsPage({Key? key, this.onSettingsChanged}) : super(key: key);
+  final ValueChanged<Locale>? onLanguageChanged;
+  const SettingsPage({Key? key, this.onSettingsChanged, this.onLanguageChanged})
+      : super(key: key);
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -12,6 +14,16 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   bool _notifications = false;
   bool _swipeLeftDelete = Config.swipeLeftDelete;
+  late Locale _selectedLocale;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedLocale = WidgetsBinding.instance.platformDispatcher.locale;
+    if (!Config.supportedLocales.contains(_selectedLocale)) {
+      _selectedLocale = Config.supportedLocales.first;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,6 +44,25 @@ class _SettingsPageState extends State<SettingsPage> {
               Config.swipeLeftDelete = val;
               widget.onSettingsChanged?.call();
             },
+          ),
+          ListTile(
+            title: const Text('Language'),
+            trailing: DropdownButton<Locale>(
+              value: _selectedLocale,
+              onChanged: (Locale? val) {
+                if (val == null) return;
+                setState(() => _selectedLocale = val);
+                widget.onLanguageChanged?.call(val);
+              },
+              items: Config.supportedLocales.map((locale) {
+                final name =
+                    Config.localeNames[locale.languageCode] ?? locale.toString();
+                return DropdownMenuItem(
+                  value: locale,
+                  child: Text(name),
+                );
+              }).toList(),
+            ),
           ),
         ],
       ),

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../config.dart';
+import '../l10n/app_localizations.dart';
 
 class SettingsPage extends StatefulWidget {
   final VoidCallback? onSettingsChanged;
@@ -27,17 +28,18 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(title: Text(l10n.settings)),
       body: ListView(
         children: [
           SwitchListTile(
-            title: const Text('Enable notifications'),
+            title: Text(l10n.enableNotifications),
             value: _notifications,
             onChanged: (val) => setState(() => _notifications = val),
           ),
           SwitchListTile(
-            title: const Text('Swipe left to delete'),
+            title: Text(l10n.swipeLeftDelete),
             value: _swipeLeftDelete,
             onChanged: (val) {
               setState(() => _swipeLeftDelete = val);
@@ -46,7 +48,7 @@ class _SettingsPageState extends State<SettingsPage> {
             },
           ),
           ListTile(
-            title: const Text('Language'),
+            title: Text(l10n.language),
             trailing: DropdownButton<Locale>(
               value: _selectedLocale,
               onChanged: (Locale? val) {

--- a/lib/ui/task_detail_page.dart
+++ b/lib/ui/task_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/task.dart';
+import '../l10n/app_localizations.dart';
 
 class TaskDetailPage extends StatelessWidget {
   final Task task;
@@ -7,8 +8,9 @@ class TaskDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Task Details')),
+      appBar: AppBar(title: Text(l10n.taskDetails)),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -24,18 +26,18 @@ class TaskDetailPage extends StatelessWidget {
             ],
             if (task.note.isNotEmpty) ...[
               const SizedBox(height: 8),
-              Text('Note: ${task.note}'),
+              Text('${l10n.note}: ${task.note}'),
             ],
             if (task.label.isNotEmpty) ...[
               const SizedBox(height: 8),
-              Text('Label: ${task.label}'),
+              Text('${l10n.label}: ${task.label}'),
             ],
             if (task.dueDate != null) ...[
               const SizedBox(height: 8),
-              Text('Due: ${task.dueDate!.toLocal().toString().split(' ')[0]}'),
+              Text('${l10n.due}: ${task.dueDate!.toLocal().toString().split(' ')[0]}'),
             ],
             const SizedBox(height: 8),
-            Text('Completed: ${task.isDone ? 'Yes' : 'No'}'),
+            Text('${l10n.completed}: ${task.isDone ? l10n.yes : l10n.no}'),
           ],
         ),
       ),

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'dart:async';
 import '../models/task.dart';
 import '../config.dart';
+import '../l10n/app_localizations.dart';
 
 class TaskTile extends StatefulWidget {
   final Task task;
@@ -143,7 +144,7 @@ class _TaskTileState extends State<TaskTile>
                 : (widget.showSwipeButton
                     ? IconButton(
                         icon: const Icon(Icons.swipe),
-                        tooltip: 'Reschedule',
+                        tooltip: AppLocalizations.of(context).reschedule,
                         onPressed: _startOptions,
                       )
                     : null),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   cupertino_icons: ^1.0.2
   path_provider: ^2.0.0
   flutter_markdown: ^0.6.10
+  flutter_localizations:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- make `MyApp` stateful so it can change locale
- add supported locales to config
- allow user to choose app language in settings
- update `HomePage` to apply selected locale
- include Flutter localizations in `pubspec`

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686387f1ec28832b93ea89a63faaeb4f