### PR TITLE
Add calendar tab

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -15,6 +15,7 @@ class Config {
   ];
 
   static const List<String> tabs = [
+    'Calendar',
     'Today',
     'Tomorrow',
     'Day After Tomorrow',

--- a/lib/ui/calendar_tab.dart
+++ b/lib/ui/calendar_tab.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+/// Calendar tab with week and month views.
+class CalendarTab extends StatefulWidget {
+  const CalendarTab({Key? key}) : super(key: key);
+
+  @override
+  State<CalendarTab> createState() => _CalendarTabState();
+}
+
+class _CalendarTabState extends State<CalendarTab>
+    with SingleTickerProviderStateMixin {
+  late TabController _viewController;
+  DateTime _focusedDay = DateTime.now();
+
+  static const _weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+  @override
+  void initState() {
+    super.initState();
+    _viewController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _viewController.dispose();
+    super.dispose();
+  }
+
+  Widget _buildWeekView() {
+    final startOfWeek =
+        _focusedDay.subtract(Duration(days: _focusedDay.weekday - 1));
+    final days =
+        List.generate(7, (i) => startOfWeek.add(Duration(days: i)));
+    return Column(
+      children: [
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            for (int i = 0; i < days.length; i++)
+              Column(
+                children: [
+                  Text(_weekdays[i]),
+                  const SizedBox(height: 4),
+                  CircleAvatar(
+                    radius: 18,
+                    child: Text('${days[i].day}'),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMonthView() {
+    return CalendarDatePicker(
+      initialDate: _focusedDay,
+      firstDate: DateTime(_focusedDay.year - 1),
+      lastDate: DateTime(_focusedDay.year + 1),
+      onDateChanged: (d) => setState(() => _focusedDay = d),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TabBar(
+          controller: _viewController,
+          tabs: const [Tab(text: 'Week'), Tab(text: 'Month')],
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _viewController,
+            children: [
+              _buildWeekView(),
+              _buildMonthView(),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/calendar_tab.dart
+++ b/lib/ui/calendar_tab.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import '../models/task.dart';
 
-/// Calendar tab with week and month views.
+/// Calendar tab with week and month views that displays tasks.
 class CalendarTab extends StatefulWidget {
-  const CalendarTab({Key? key}) : super(key: key);
+  final List<Task> tasks;
+  final DateTime currentDate;
+
+  const CalendarTab({Key? key, required this.tasks, required this.currentDate})
+      : super(key: key);
 
   @override
   State<CalendarTab> createState() => _CalendarTabState();
@@ -19,6 +24,15 @@ class _CalendarTabState extends State<CalendarTab>
   void initState() {
     super.initState();
     _viewController = TabController(length: 2, vsync: this);
+    _focusedDay = widget.currentDate;
+  }
+
+  @override
+  void didUpdateWidget(covariant CalendarTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.currentDate != oldWidget.currentDate) {
+      setState(() => _focusedDay = widget.currentDate);
+    }
   }
 
   @override
@@ -32,26 +46,53 @@ class _CalendarTabState extends State<CalendarTab>
         _focusedDay.subtract(Duration(days: _focusedDay.weekday - 1));
     final days =
         List.generate(7, (i) => startOfWeek.add(Duration(days: i)));
-    return Column(
-      children: [
-        const SizedBox(height: 16),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             for (int i = 0; i < days.length; i++)
-              Column(
-                children: [
-                  Text(_weekdays[i]),
-                  const SizedBox(height: 4),
-                  CircleAvatar(
-                    radius: 18,
-                    child: Text('${days[i].day}'),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Center(child: Text(_weekdays[i])),
+                      const SizedBox(height: 4),
+                      Center(
+                        child: CircleAvatar(
+                          radius: 18,
+                          child: Text('${days[i].day}'),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      for (final task in widget.tasks.where((t) =>
+                          t.dueDate != null &&
+                          t.dueDate!.year == days[i].year &&
+                          t.dueDate!.month == days[i].month &&
+                          t.dueDate!.day == days[i].day))
+                        Container(
+                          margin: const EdgeInsets.symmetric(vertical: 2),
+                          padding: const EdgeInsets.all(4),
+                          decoration: BoxDecoration(
+                            color: Colors.blueAccent.withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            task.title,
+                            style: const TextStyle(fontSize: 12),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                    ],
                   ),
-                ],
+                ),
               ),
           ],
         ),
-      ],
+      ),
     );
   }
 

--- a/lib/ui/calendar_tab.dart
+++ b/lib/ui/calendar_tab.dart
@@ -97,11 +97,86 @@ class _CalendarTabState extends State<CalendarTab>
   }
 
   Widget _buildMonthView() {
-    return CalendarDatePicker(
-      initialDate: _focusedDay,
-      firstDate: DateTime(_focusedDay.year - 1),
-      lastDate: DateTime(_focusedDay.year + 1),
-      onDateChanged: (d) => setState(() => _focusedDay = d),
+    final firstDayOfMonth = DateTime(_focusedDay.year, _focusedDay.month, 1);
+    final daysBefore = firstDayOfMonth.weekday - 1;
+    final lastDay = DateTime(_focusedDay.year, _focusedDay.month + 1, 0).day;
+    final total = daysBefore + lastDay;
+    final weeks = (total / 7).ceil();
+    final start = firstDayOfMonth.subtract(Duration(days: daysBefore));
+    final days =
+        List.generate(weeks * 7, (i) => start.add(Duration(days: i)));
+
+    Widget dayCell(DateTime day) {
+      final tasksForDay = widget.tasks.where((t) =>
+          t.dueDate != null &&
+          t.dueDate!.year == day.year &&
+          t.dueDate!.month == day.month &&
+          t.dueDate!.day == day.day);
+      final faded = day.month != _focusedDay.month;
+      return GestureDetector(
+        onTap: () => setState(() => _focusedDay = day),
+        child: Padding(
+          padding: const EdgeInsets.all(2.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: CircleAvatar(
+                  radius: 14,
+                  backgroundColor:
+                      faded ? Colors.grey.shade300 : Colors.blue.shade50,
+                  child: Text(
+                    '${day.day}',
+                    style: TextStyle(
+                        fontSize: 12,
+                        color: faded ? Colors.grey : Colors.black),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 2),
+              for (final task in tasksForDay)
+                Container(
+                  margin: const EdgeInsets.symmetric(vertical: 1),
+                  padding: const EdgeInsets.all(2),
+                  decoration: BoxDecoration(
+                    color: Colors.blueAccent.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    task.title,
+                    style: const TextStyle(fontSize: 10),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                for (final w in _weekdays)
+                  Expanded(child: Center(child: Text(w))),
+              ],
+            ),
+            const SizedBox(height: 4),
+            for (int w = 0; w < weeks; w++)
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (int i = 0; i < 7; i++)
+                    Expanded(child: dayCell(days[w * 7 + i])),
+                ],
+              ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -54,7 +54,7 @@ class _HomePageState extends State<HomePage>
   void initState() {
     super.initState();
     _tabController =
-        TabController(length: Config.tabs.length, vsync: this);
+        TabController(length: Config.tabs.length, vsync: this, initialIndex: 1);
     _loadTasks();
   }
 

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -8,6 +8,7 @@ import 'about_page.dart';
 import 'settings_page.dart';
 import 'deleted_items_page.dart';
 import 'changelog_page.dart';
+import 'calendar_tab.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -66,7 +67,9 @@ class _HomePageState extends State<HomePage>
 
   void _addTask(String title) {
     if (title.trim().isEmpty) return;
-    final offset = _offsetDays[_tabController.index];
+    final tabIndex = _tabController.index - 1;
+    if (tabIndex < 0 || tabIndex >= _offsetDays.length) return;
+    final offset = _offsetDays[tabIndex];
     final task = Task(
       title: title,
       dueDate: _currentDate.add(Duration(days: offset)),
@@ -81,7 +84,7 @@ class _HomePageState extends State<HomePage>
   void _moveTaskToNextPage(int pageIndex, int index) {
     final tasks = _tasksForTab(pageIndex);
     int destination = pageIndex + 1;
-    if (destination >= Config.tabs.length) {
+    if (destination >= _offsetDays.length) {
       destination = 0;
     }
     setState(() {
@@ -98,8 +101,10 @@ class _HomePageState extends State<HomePage>
       final tasks = _tasksForTab(pageIndex);
       if (index >= tasks.length) return;
       final task = tasks[index];
+      final destIndex = destination - 1;
+      if (destIndex < 0 || destIndex >= _offsetDays.length) return;
       task.dueDate =
-          _currentDate.add(Duration(days: _offsetDays[destination]));
+          _currentDate.add(Duration(days: _offsetDays[destIndex]));
     });
     _storageService.saveTaskList(_tasks);
   }
@@ -339,6 +344,7 @@ class _HomePageState extends State<HomePage>
       body: TabBarView(
         controller: _tabController,
         children: [
+          const CalendarTab(),
           _buildTaskList(0),
           _buildTaskList(1),
           _buildTaskList(2),

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -344,7 +344,7 @@ class _HomePageState extends State<HomePage>
       body: TabBarView(
         controller: _tabController,
         children: [
-          const CalendarTab(),
+          CalendarTab(tasks: _tasks, currentDate: _currentDate),
           _buildTaskList(0),
           _buildTaskList(1),
           _buildTaskList(2),

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -54,7 +54,8 @@ class _TaskTileState extends State<TaskTile>
       duration: Duration(seconds: Config.defaultDelaySeconds),
     );
     _destinations = List<int>.generate(Config.tabs.length, (i) => i)
-      ..remove(widget.pageIndex);
+        .where((i) => i != widget.pageIndex && i != 0)
+        .toList();
   }
 
   void _startOptions() {

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -53,9 +53,11 @@ class _TaskTileState extends State<TaskTile>
       vsync: this,
       duration: Duration(seconds: Config.defaultDelaySeconds),
     );
-    _destinations = List<int>.generate(Config.tabs.length, (i) => i)
-        .where((i) => i != widget.pageIndex && i != 0)
-        .toList();
+    // Destination indices correspond to the tab indices defined in Config.
+    // Skip the calendar tab (index 0) and the current tab.
+    _destinations =
+        List<int>.generate(Config.tabs.length - 1, (i) => i + 1)
+          ..remove(widget.pageIndex + 1);
   }
 
   void _startOptions() {


### PR DESCRIPTION
## Summary
- add a new `Calendar` tab with week and month views
- update task destination logic to ignore the calendar tab
- shift task tab calculations to account for the new tab

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686387108f34832bb61dcf49c324f7fd