### PR TITLE
Show version in home page

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -305,7 +305,7 @@ class _HomePageState extends State<HomePage>
         ),
       ),
       appBar: AppBar(
-        title: const Text('Best Todo 2'),
+        title: Text('Best Todo 2 v${Config.version}'),
         bottom: PreferredSize(
           preferredSize: Size.fromHeight(Config.isDev ? 72 : 48),
           child: Column(


### PR DESCRIPTION
## Summary
- display app version in the home page title

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863acd4354c832bb0f13dffd57c3424