### PR TITLE
Update due date behaviors

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -158,6 +158,11 @@ class _HomePageState extends State<HomePage>
     setState(() {});
   }
 
+  void _taskDueDateChanged() {
+    setState(() {});
+    _storageService.saveTaskList(_tasks);
+  }
+
   /// Change the current virtual date by the given number of days.
   /// When moving forward, overdue tasks remain visible in the Today tab.
   void _changeDate(int delta) {
@@ -221,6 +226,7 @@ class _HomePageState extends State<HomePage>
                 onMove: (dest) => _moveTask(pageIndex, index, dest),
                 onMoveNext: () => _moveTaskToNextPage(pageIndex, index),
                 onDelete: () => _deleteTask(pageIndex, index),
+                onDueDateChanged: _taskDueDateChanged,
                 pageIndex: pageIndex,
                 showSwipeButton: !isAndroid,
                 swipeLeftDelete: Config.swipeLeftDelete,

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -82,6 +82,7 @@ class _TaskTileState extends State<TaskTile>
 
   void _toggleExpanded() {
     setState(() => _expanded = !_expanded);
+    widget.onDueDateChanged();
   }
 
   @override

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -10,6 +10,7 @@ class TaskTile extends StatefulWidget {
   final void Function(int destination) onMove;
   final VoidCallback onMoveNext;
   final VoidCallback onDelete;
+  final VoidCallback onDueDateChanged;
   final int pageIndex;
   final bool showSwipeButton;
   final bool swipeLeftDelete;
@@ -21,6 +22,7 @@ class TaskTile extends StatefulWidget {
     required this.onMove,
     required this.onMoveNext,
     required this.onDelete,
+    required this.onDueDateChanged,
     required this.pageIndex,
     this.showSwipeButton = true,
     this.swipeLeftDelete = true,
@@ -190,6 +192,7 @@ class _TaskTileState extends State<TaskTile>
                           );
                           if (picked != null) {
                             setState(() => widget.task.dueDate = picked);
+                            widget.onDueDateChanged();
                           }
                         },
                         child: const Text('Pick due date'),


### PR DESCRIPTION
## Summary
- move task tile when due date field is changed
- expose a callback for due date edits

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640b531bdc832ba1bc8aa8fd7acba3