### PR TITLE
Update path_provider for Android v2 embedding

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,14 @@ publish_to: 'none'
 version: 0.1.3
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
-  path_provider: ^2.0.0
+  path_provider: ^2.1.2
   flutter_markdown: ^0.6.10
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- update Dart SDK constraint to allow newer Flutter tooling
- upgrade path_provider to version that supports Android v2 embedding

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a14201fc0832b8952d42bfb1be47c