### PR TITLE
Add Android widget displaying app version

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,18 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <receiver
+            android:name=".VersionWidgetProvider"
+            android:exported="false"
+            android:label="@string/version_widget_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/version_widget_info" />
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/example/best_todo_2/VersionWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/VersionWidgetProvider.kt
@@ -1,0 +1,20 @@
+package com.example.best_todo_2
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.widget.RemoteViews
+
+class VersionWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            val views = RemoteViews(context.packageName, R.layout.version_widget)
+            views.setTextViewText(R.id.appwidget_text, BuildConfig.VERSION_NAME)
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/res/layout/version_widget.xml
+++ b/android/app/src/main/res/layout/version_widget.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/transparent">
+
+    <TextView
+        android:id="@+id/appwidget_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/version_widget_name"
+        android:textSize="16sp" />
+</FrameLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="version_widget_name">App Version</string>
+</resources>

--- a/android/app/src/main/res/xml/version_widget_info.xml
+++ b/android/app/src/main/res/xml/version_widget_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/version_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary
- add `VersionWidgetProvider` to show the app's current version as an Android home screen widget
- create widget layout and provider metadata resources
- register the widget provider in the Android manifest

## Testing
- `flutter test` *(fails: command not found)*
- `gradle -p android assembleDebug` *(fails: /workspace/best_todo_2/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_689f06eb0b10832bae2d5f4b485d482c