### PR TITLE
Display today’s tasks in widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [0.1.6] - 2025-08-15
-- a working version where the widget shows the version number
+- widget now lists today's tasks and opens the app when tapped
 
 ## [0.1.5] - 2025-08-15
 - cleanup main branch with android folder attached

--- a/android/app/src/main/kotlin/com/example/best_todo_2/VersionWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/VersionWidgetProvider.kt
@@ -1,10 +1,16 @@
 package com.example.best_todo_2
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
+import android.content.Intent
 import android.widget.RemoteViews
-import com.example.best_todo_2.BuildConfig
+import org.json.JSONArray
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class VersionWidgetProvider : AppWidgetProvider() {
     override fun onUpdate(
@@ -14,7 +20,41 @@ class VersionWidgetProvider : AppWidgetProvider() {
     ) {
         for (appWidgetId in appWidgetIds) {
             val views = RemoteViews(context.packageName, R.layout.version_widget)
-            views.setTextViewText(R.id.appwidget_text, BuildConfig.VERSION_NAME)
+
+            val tasksFile = File(context.filesDir, "tasks.json")
+            val displayText = if (tasksFile.exists()) {
+                try {
+                    val json = JSONArray(tasksFile.readText())
+                    val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                    val today = sdf.format(Date())
+                    val titles = mutableListOf<String>()
+                    for (i in 0 until json.length()) {
+                        val obj = json.getJSONObject(i)
+                        val dueDate = obj.optString("dueDate", "").take(10)
+                        val isDone = obj.optBoolean("isDone", false)
+                        if (!isDone && dueDate == today) {
+                            titles.add(obj.optString("title", ""))
+                        }
+                    }
+                    if (titles.isNotEmpty()) titles.joinToString("\n") else "No tasks for today"
+                } catch (e: Exception) {
+                    "No tasks for today"
+                }
+            } else {
+                "No tasks for today"
+            }
+
+            views.setTextViewText(R.id.appwidget_text, displayText)
+
+            val intent = Intent(context, MainActivity::class.java)
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            views.setOnClickPendingIntent(R.id.widget_container, pendingIntent)
+
             appWidgetManager.updateAppWidget(appWidgetId, views)
         }
     }

--- a/android/app/src/main/res/layout/version_widget.xml
+++ b/android/app/src/main/res/layout/version_widget.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/transparent">
@@ -7,8 +8,8 @@
     <TextView
         android:id="@+id/appwidget_text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
+        android:layout_height="wrap_content"
+        android:gravity="start"
         android:text="@string/version_widget_name"
         android:textSize="16sp" />
 </FrameLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="version_widget_name">App Version</string>
+    <string name="version_widget_name">Today's Tasks</string>
 </resources>


### PR DESCRIPTION
## Summary
- Replace version widget text with a list of tasks due today
- Open the app when tapping the widget
- Update changelog and widget label

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689f0cfb18d8832b8ccb394b3a3b621b