### PR TITLE
Open app from version widget

### DIFF
--- a/android/app/src/main/kotlin/com/example/best_todo_2/VersionWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/VersionWidgetProvider.kt
@@ -2,7 +2,9 @@ package com.example.best_todo_2
 
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.widget.RemoteViews
 import com.example.best_todo_2.BuildConfig
 
@@ -15,6 +17,14 @@ class VersionWidgetProvider : AppWidgetProvider() {
         for (appWidgetId in appWidgetIds) {
             val views = RemoteViews(context.packageName, R.layout.version_widget)
             views.setTextViewText(R.id.appwidget_text, BuildConfig.VERSION_NAME)
+            val intent = Intent(context, MainActivity::class.java)
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            views.setOnClickPendingIntent(R.id.appwidget_text, pendingIntent)
             appWidgetManager.updateAppWidget(appWidgetId, views)
         }
     }


### PR DESCRIPTION
## Summary
- Launch main activity when tapping the Android version widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f28c98290832bad52f30ba17615ee