### PR TITLE
feat: add user logs page

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="version_widget_name">Tasks Due Today</string>
-    <string name="no_tasks_today">No tasks due today</string>
+    <string name="version_widget_name">Due Tasks</string>
+    <string name="no_tasks_today">No due tasks</string>
 </resources>

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/foundation.dart';
 
-/// Simple in-memory logger to track user interactions and widget updates.
+/// Simple in-memory logger to track app interactions and widget updates.
 class LogService {
   // ValueNotifier so UI can listen to log updates.
   static final ValueNotifier<List<String>> logs =
       ValueNotifier<List<String>>(<String>[]);
 
-  /// Add a log entry with a timestamp.
-  static void add(String message) {
+  /// Add a log entry with a timestamp and source.
+  static void add(String source, String message) {
     final timestamp = DateTime.now().toIso8601String();
-    logs.value = List<String>.from(logs.value)..add('$timestamp: $message');
+    logs.value = List<String>.from(logs.value)
+      ..add('$timestamp [$source] $message');
   }
 
   /// Clear all log entries.

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/foundation.dart';
+
+/// Simple in-memory logger to track user interactions and widget updates.
+class LogService {
+  // ValueNotifier so UI can listen to log updates.
+  static final ValueNotifier<List<String>> logs =
+      ValueNotifier<List<String>>(<String>[]);
+
+  /// Add a log entry with a timestamp.
+  static void add(String message) {
+    final timestamp = DateTime.now().toIso8601String();
+    logs.value = List<String>.from(logs.value)..add('$timestamp: $message');
+  }
+
+  /// Clear all log entries.
+  static void clear() {
+    logs.value = <String>[];
+  }
+}

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -8,8 +8,19 @@ class LogService {
 
   /// Add a log entry with a timestamp and source.
   static void add(String source, String message) {
-    final timestamp = DateTime.now().toIso8601String();
-    logs.value = List<String>.from(logs.value)
+    final now = DateTime.now();
+    final timestamp = now.toIso8601String();
+    final cutoff = now.subtract(const Duration(days: 1));
+
+    // Keep only entries from the last 24 hours before adding the new one.
+    final recent = logs.value.where((entry) {
+      final spaceIndex = entry.indexOf(' ');
+      if (spaceIndex == -1) return false;
+      final entryTime = DateTime.tryParse(entry.substring(0, spaceIndex));
+      return entryTime != null && !entryTime.isBefore(cutoff);
+    });
+
+    logs.value = List<String>.from(recent)
       ..add('$timestamp [$source] $message');
   }
 

--- a/lib/ui/app_logs_page.dart
+++ b/lib/ui/app_logs_page.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 
 import '../services/log_service.dart';
 
-/// Displays logs collected during user interactions and widget updates.
-class UserLogsPage extends StatelessWidget {
-  const UserLogsPage({Key? key}) : super(key: key);
+/// Displays logs collected during app interactions and widget updates.
+class AppLogsPage extends StatelessWidget {
+  const AppLogsPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('User Logs')),
+      appBar: AppBar(title: const Text('App Logs')),
       body: ValueListenableBuilder<List<String>>(
         valueListenable: LogService.logs,
         builder: (context, logs, _) {

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -9,7 +9,7 @@ import 'about_page.dart';
 import 'settings_page.dart';
 import 'deleted_items_page.dart';
 import 'changelog_page.dart';
-import 'user_logs_page.dart';
+import 'app_logs_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -46,7 +46,8 @@ class _HomePageState extends State<HomePage>
     } else {
       _tasks.addAll(loaded);
     }
-    LogService.add('Loaded ${_tasks.length} tasks');
+    LogService.add('HomePage._loadTasks',
+        '*** Tasks loaded into widget (${_tasks.length}) ***');
     if (mounted) {
       setState(() {});
     }
@@ -79,7 +80,7 @@ class _HomePageState extends State<HomePage>
     });
     _controller.clear();
     _storageService.saveTaskList(_tasks);
-    LogService.add('Added task: $title');
+    LogService.add('HomePage._addTask', 'Added task: $title');
   }
 
   void _moveTaskToNextPage(int pageIndex, int index) {
@@ -95,7 +96,8 @@ class _HomePageState extends State<HomePage>
           _currentDate.add(Duration(days: _offsetDays[destination]));
     });
     _storageService.saveTaskList(_tasks);
-    LogService.add('Moved "${task.title}" to page $destination');
+    LogService.add('HomePage._moveTaskToNextPage',
+        'Moved "${task.title}" to page $destination');
   }
 
   void _moveTask(int pageIndex, int index, int destination) {
@@ -107,7 +109,8 @@ class _HomePageState extends State<HomePage>
           _currentDate.add(Duration(days: _offsetDays[destination]));
     });
     _storageService.saveTaskList(_tasks);
-    LogService.add('Moved "${task.title}" to page $destination');
+    LogService.add(
+        'HomePage._moveTask', 'Moved "${task.title}" to page $destination');
   }
 
   void _deleteTask(int pageIndex, int index) {
@@ -120,7 +123,7 @@ class _HomePageState extends State<HomePage>
       _tasks.removeAt(originalIndex);
     });
     _storageService.saveTaskList(_tasks);
-    LogService.add('Deleted "${task.title}"');
+    LogService.add('HomePage._deleteTask', 'Deleted "${task.title}"');
 
     late Timer timer;
     timer = Timer(const Duration(seconds: Config.defaultDelaySeconds), () {
@@ -146,7 +149,8 @@ class _HomePageState extends State<HomePage>
                 _tasks.insert(originalIndex, task);
               });
               _storageService.saveTaskList(_tasks);
-              LogService.add('Restored from undo "${task.title}"');
+              LogService.add('HomePage._deleteTask',
+                  'Restored from undo "${task.title}"');
             },
           ),
         ),
@@ -160,12 +164,12 @@ class _HomePageState extends State<HomePage>
       _tasks.add(task);
     });
     _storageService.saveTaskList(_tasks);
-    LogService.add('Restored "${task.title}"');
+    LogService.add('HomePage._restoreTask', 'Restored "${task.title}"');
   }
 
   void _updateSettings() {
     setState(() {});
-    LogService.add('Settings updated');
+    LogService.add('HomePage._updateSettings', 'Settings updated');
   }
 
   /// Change the current virtual date by the given number of days.
@@ -180,7 +184,8 @@ class _HomePageState extends State<HomePage>
       }
     });
     _storageService.saveTaskList(_tasks);
-    LogService.add('Changed date by $delta to $_currentDate');
+    LogService.add('HomePage._changeDate',
+        'Changed date by $delta to $_currentDate');
   }
 
   /// Returns the list of tasks that should appear on the given tab index.
@@ -197,7 +202,8 @@ class _HomePageState extends State<HomePage>
 
   Widget _buildTaskList(int pageIndex) {
     final tasks = _tasksForTab(pageIndex);
-    LogService.add('Building tab $pageIndex with ${tasks.length} tasks');
+    LogService.add('HomePage._buildTaskList',
+        'Building tab $pageIndex with ${tasks.length} tasks');
     return Column(
       children: [
         Padding(
@@ -300,11 +306,11 @@ class _HomePageState extends State<HomePage>
             ),
             ListTile(
               leading: const Icon(Icons.list_alt),
-              title: const Text('User Logs'),
+              title: const Text('App Logs'),
               onTap: () {
                 Navigator.pop(context);
                 Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const UserLogsPage()),
+                  MaterialPageRoute(builder: (_) => const AppLogsPage()),
                 );
               },
             ),

--- a/lib/ui/user_logs_page.dart
+++ b/lib/ui/user_logs_page.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../services/log_service.dart';
+
+/// Displays logs collected during user interactions and widget updates.
+class UserLogsPage extends StatelessWidget {
+  const UserLogsPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('User Logs')),
+      body: ValueListenableBuilder<List<String>>(
+        valueListenable: LogService.logs,
+        builder: (context, logs, _) {
+          if (logs.isEmpty) {
+            return const Center(child: Text('No logs yet'));
+          }
+          return ListView.builder(
+            itemCount: logs.length,
+            itemBuilder: (context, index) => ListTile(
+              dense: true,
+              title: Text(logs[index]),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: LogService.clear,
+        tooltip: 'Clear logs',
+        child: const Icon(Icons.delete),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add in-memory log service
- expose User Logs page from the menu
- log interactions and widget builds to aid debugging

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a071fbbe50832b84b7a1846b92fca9