### PR TITLE
Ensure widget uses white background with black text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.9] - 2025-08-15
+- updated widget color to be better visible on all devices
+
 ## [0.1.8] - 2025-08-15
 - Widget now displays tasks due today instead of app version.
 

--- a/android/app/src/main/res/layout/version_widget.xml
+++ b/android/app/src/main/res/layout/version_widget.xml
@@ -2,7 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/transparent">
+    android:background="#00FF00">
 
     <TextView
         android:id="@+id/appwidget_text"
@@ -11,6 +11,7 @@
         android:gravity="start|top"
         android:padding="8dp"
         android:text="@string/version_widget_name"
+        android:textColor="#FF0000"
         android:textSize="14sp"
         android:lineSpacingExtra="2dp" />
 </FrameLayout>

--- a/android/app/src/main/res/layout/version_widget.xml
+++ b/android/app/src/main/res/layout/version_widget.xml
@@ -2,7 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#00FF00">
+    android:background="#ffffffc8">
 
     <TextView
         android:id="@+id/appwidget_text"
@@ -11,7 +11,7 @@
         android:gravity="start|top"
         android:padding="8dp"
         android:text="@string/version_widget_name"
-        android:textColor="#FF0000"
+        android:textColor="#000000ff"
         android:textSize="14sp"
         android:lineSpacingExtra="2dp" />
 </FrameLayout>

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -6,7 +6,7 @@ class Config {
   static const bool isDev = !bool.fromEnvironment('dart.vm.product');
 
   /// Current application version.
-  static const String version = '0.1.8';
+  static const String version = '0.1.9';
 
   static const List<String> initialTasks = [
     'Get milk',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,13 +23,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Best Todo 2',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        scaffoldBackgroundColor: Colors.green,
-        textTheme: ThemeData.light()
-            .textTheme
-            .apply(bodyColor: Colors.red, displayColor: Colors.red),
-      ),
+      theme: ThemeData(primarySwatch: Colors.blue),
       darkTheme: ThemeData.dark(),
       themeMode: Config.darkMode ? ThemeMode.dark : ThemeMode.light,
       home: const HomePage(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,10 +25,10 @@ class _MyAppState extends State<MyApp> {
       title: 'Best Todo 2',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        scaffoldBackgroundColor: Colors.white,
+        scaffoldBackgroundColor: Colors.green,
         textTheme: ThemeData.light()
             .textTheme
-            .apply(bodyColor: Colors.black, displayColor: Colors.black),
+            .apply(bodyColor: Colors.red, displayColor: Colors.red),
       ),
       darkTheme: ThemeData.dark(),
       themeMode: Config.darkMode ? ThemeMode.dark : ThemeMode.light,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,7 +23,13 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Best Todo 2',
-      theme: ThemeData(primarySwatch: Colors.blue),
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+        scaffoldBackgroundColor: Colors.white,
+        textTheme: ThemeData.light()
+            .textTheme
+            .apply(bodyColor: Colors.black, displayColor: Colors.black),
+      ),
       darkTheme: ThemeData.dark(),
       themeMode: Config.darkMode ? ThemeMode.dark : ThemeMode.light,
       home: const HomePage(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: best_todo_2
 description: A simple Flutter to-do application
 publish_to: 'none'
-version: 0.1.8
+version: 0.1.9
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Set app's theme to always use a white scaffold background
- Apply black text colors across the light theme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a15e6e3b04832ba22d14507ee7281f