### PR TITLE
Fix Android widget colors for readability

### DIFF
--- a/android/app/src/main/res/layout/version_widget.xml
+++ b/android/app/src/main/res/layout/version_widget.xml
@@ -2,7 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#ff6f6fff">
+    android:background="@android:color/white">
 
     <TextView
         android:id="@+id/appwidget_text"
@@ -11,7 +11,7 @@
         android:gravity="start|top"
         android:padding="8dp"
         android:text="@string/version_widget_name"
-        android:textColor="#000000ff"
+        android:textColor="@android:color/black"
         android:textSize="14sp"
         android:lineSpacingExtra="2dp" />
 </FrameLayout>


### PR DESCRIPTION
## Summary
- Replace purple widget background with white
- Use black text to ensure readable widget

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d8c3cd04832bb8edd171e083fe52