### PR TITLE
Improve widget task loading and start page configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -46,3 +46,10 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    implementation("androidx.annotation:annotation:1.7.1")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.10.3")
+    testImplementation("androidx.test:core:1.5.0")
+}

--- a/android/app/src/test/java/com/example/best_todo_2/VersionWidgetProviderTest.kt
+++ b/android/app/src/test/java/com/example/best_todo_2/VersionWidgetProviderTest.kt
@@ -1,0 +1,36 @@
+package com.example.best_todo_2
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class VersionWidgetProviderTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun loadDueTasks_readsFromFallbackLocation() {
+        val appFlutter = context.getDir("app_flutter", Context.MODE_PRIVATE)
+        File(appFlutter, "tasks.json").delete()
+
+        val file = File(context.filesDir, "tasks.json")
+        file.writeText(
+            "[{\"title\":\"Test\",\"dueDate\":\"2000-01-01T00:00:00.000\",\"isDone\":false}]"
+        )
+
+        val provider = VersionWidgetProvider()
+        val result = provider.loadDueTasks(context)
+
+        assertTrue(result.contains("Test"))
+    }
+}

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -21,6 +21,12 @@ class Config {
     'Next Week',
   ];
 
+  /// Page shown when the app starts.
+  /// Default is the app logs page.
+  static const String startPage = 'app_logs';
+  // static const String startPage = 'today'; // Today list
+  // static const String startPage = 'settings'; // Settings page
+
   /// If true, swipe left deletes a task and swipe right shows options.
   /// Otherwise the directions are reversed.
   static bool swipeLeftDelete = true;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'ui/home_page.dart';
+import 'ui/settings_page.dart';
+import 'ui/app_logs_page.dart';
 import 'config.dart';
 
 void main() {
@@ -19,6 +21,18 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   void updateTheme() => setState(() {});
 
+  Widget _initialPage() {
+    switch (Config.startPage) {
+      case 'settings':
+        return const SettingsPage();
+      case 'today':
+        return const HomePage();
+      case 'app_logs':
+      default:
+        return const AppLogsPage();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -26,7 +40,7 @@ class _MyAppState extends State<MyApp> {
       theme: ThemeData(primarySwatch: Colors.blue),
       darkTheme: ThemeData.dark(),
       themeMode: Config.darkMode ? ThemeMode.dark : ThemeMode.light,
-      home: const HomePage(),
+      home: _initialPage(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- try multiple storage locations when reading tasks for the Android home-screen widget
- add Robolectric test to verify widget can read tasks from fallback directory
- configure build with annotation and test dependencies
- allow choosing startup page via `Config.startPage` (default to app logs)

## Testing
- `flutter test` *(fails: command not found)*
- `gradle -p android test` *(fails: /workspace/best_todo_2/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68a1ed11174c832bbde8184fff8de30a