### PR TITLE
Integrate HomeWidget updates into task changes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,13 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/version_widget_info" />
         </receiver>
+        <receiver android:name=".SimpleWidgetProvider" android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data android:name="android.appwidget.provider"
+                android:resource="@xml/simple_widget_info" />
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/example/best_todo_2/SimpleWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/SimpleWidgetProvider.kt
@@ -1,0 +1,24 @@
+package com.example.test_widget_1
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+
+class SimpleWidgetProvider : HomeWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.simple_widget_layout).apply {
+                val text = widgetData.getString("text_from_flutter_app", "")
+                setTextViewText(R.id.widget_text, text)
+            }
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/example/best_todo_2/SimpleWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/SimpleWidgetProvider.kt
@@ -1,4 +1,4 @@
-package com.example.test_widget_1
+package com.example.best_todo_2
 
 import android.appwidget.AppWidgetManager
 import android.content.Context

--- a/android/app/src/main/kotlin/com/example/best_todo_2/SimpleWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/SimpleWidgetProvider.kt
@@ -1,7 +1,9 @@
 package com.example.best_todo_2
 
 import android.appwidget.AppWidgetManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.widget.RemoteViews
 import es.antonborri.home_widget.HomeWidgetProvider
@@ -18,6 +20,14 @@ class SimpleWidgetProvider : HomeWidgetProvider() {
                 val text = widgetData.getString("text_from_flutter_app", "")
                 setTextViewText(R.id.widget_text, text)
             }
+			val intent = Intent(context, MainActivity::class.java)
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            views.setOnClickPendingIntent(R.id.widget_text, pendingIntent)
             appWidgetManager.updateAppWidget(widgetId, views)
         }
     }

--- a/android/app/src/main/res/layout/simple_widget_layout.xml
+++ b/android/app/src/main/res/layout/simple_widget_layout.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:background="#FFFFFF"
+    android:padding="8dp">
+    <TextView
+        android:id="@+id/widget_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello Widget"/>
+</LinearLayout>

--- a/android/app/src/main/res/layout/simple_widget_layout.xml
+++ b/android/app/src/main/res/layout/simple_widget_layout.xml
@@ -9,7 +9,12 @@
     android:padding="8dp">
     <TextView
         android:id="@+id/widget_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello Widget"/>
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="start|top"
+        android:padding="8dp"
+        android:text="Hello Widget"
+        android:textColor="@android:color/black"
+        android:textSize="14sp"
+        android:lineSpacingExtra="2dp" />
 </LinearLayout>

--- a/android/app/src/main/res/xml/simple_widget_info.xml
+++ b/android/app/src/main/res/xml/simple_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:updatePeriodMillis="86400000"
+    android:initialLayout="@layout/simple_widget_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen">
+</appwidget-provider>

--- a/android/app/src/main/res/xml/version_widget_info.xml
+++ b/android/app/src/main/res/xml/version_widget_info.xml
@@ -2,7 +2,8 @@
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:minWidth="40dp"
     android:minHeight="40dp"
-    android:updatePeriodMillis="0"
-    android:initialLayout="@layout/version_widget"
+    android:updatePeriodMillis="86400000"
+    android:initialLayout="@layout/simple_widget_layout"
     android:resizeMode="horizontal|vertical"
-    android:widgetCategory="home_screen" />
+    android:widgetCategory="home_screen">
+</appwidget-provider>

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -4,6 +4,7 @@ import '../models/task.dart';
 import '../config.dart';
 import '../services/storage_service.dart';
 import '../services/log_service.dart';
+import 'package:home_widget/home_widget.dart';
 import 'task_tile.dart';
 import 'about_page.dart';
 import 'settings_page.dart';
@@ -30,6 +31,11 @@ class _HomePageState extends State<HomePage>
   final List<Task> _deletedTasks = [];
   final StorageService _storageService = StorageService();
 
+  final String appGroupId = 'group.homeScreenApp';
+  final String iOSWidgetName = 'SimpleWidgetProvider';
+  final String androidWidgetName = 'SimpleWidgetProvider';
+  final String dataKey = 'text_from_flutter_app';
+
   late final TabController _tabController;
   final TextEditingController _controller = TextEditingController();
 
@@ -51,6 +57,7 @@ class _HomePageState extends State<HomePage>
     if (mounted) {
       setState(() {});
     }
+    _updateHomeWidget();
   }
 
   @override
@@ -58,6 +65,7 @@ class _HomePageState extends State<HomePage>
     super.initState();
     _tabController =
         TabController(length: Config.tabs.length, vsync: this);
+    HomeWidget.setAppGroupId(appGroupId).catchError((_) {});
     _loadTasks();
   }
 
@@ -79,7 +87,7 @@ class _HomePageState extends State<HomePage>
       _tasks.add(task);
     });
     _controller.clear();
-    _storageService.saveTaskList(_tasks);
+    _saveTasks();
     LogService.add('HomePage._addTask', 'Added task: $title');
   }
 
@@ -95,7 +103,7 @@ class _HomePageState extends State<HomePage>
       task.dueDate =
           _currentDate.add(Duration(days: _offsetDays[destination]));
     });
-    _storageService.saveTaskList(_tasks);
+    _saveTasks();
     LogService.add('HomePage._moveTaskToNextPage',
         'Moved "${task.title}" to page $destination');
   }
@@ -108,7 +116,7 @@ class _HomePageState extends State<HomePage>
       task.dueDate =
           _currentDate.add(Duration(days: _offsetDays[destination]));
     });
-    _storageService.saveTaskList(_tasks);
+    _saveTasks();
     LogService.add(
         'HomePage._moveTask', 'Moved "${task.title}" to page $destination');
   }
@@ -122,7 +130,7 @@ class _HomePageState extends State<HomePage>
     setState(() {
       _tasks.removeAt(originalIndex);
     });
-    _storageService.saveTaskList(_tasks);
+    _saveTasks();
     LogService.add('HomePage._deleteTask', 'Deleted "${task.title}"');
 
     late Timer timer;
@@ -148,7 +156,7 @@ class _HomePageState extends State<HomePage>
               setState(() {
                 _tasks.insert(originalIndex, task);
               });
-              _storageService.saveTaskList(_tasks);
+              _saveTasks();
               LogService.add('HomePage._deleteTask',
                   'Restored from undo "${task.title}"');
             },
@@ -163,7 +171,7 @@ class _HomePageState extends State<HomePage>
       task.dueDate = _currentDate;
       _tasks.add(task);
     });
-    _storageService.saveTaskList(_tasks);
+    _saveTasks();
     LogService.add('HomePage._restoreTask', 'Restored "${task.title}"');
   }
 
@@ -183,9 +191,23 @@ class _HomePageState extends State<HomePage>
         _tasks.removeWhere((t) => t.isDone);
       }
     });
-    _storageService.saveTaskList(_tasks);
+    _saveTasks();
     LogService.add('HomePage._changeDate',
         'Changed date by $delta to $_currentDate');
+  }
+
+  Future<void> _updateHomeWidget() async {
+    final data = _tasks.map((t) => t.title).join('\n');
+    try {
+      await HomeWidget.saveWidgetData(dataKey, data);
+      await HomeWidget.updateWidget(
+          iOSName: iOSWidgetName, androidName: androidWidgetName);
+    } catch (_) {}
+  }
+
+  void _saveTasks() {
+    _storageService.saveTaskList(_tasks);
+    _updateHomeWidget();
   }
 
   /// Returns the list of tasks that should appear on the given tab index.
@@ -234,7 +256,7 @@ class _HomePageState extends State<HomePage>
                 task: task,
                 onChanged: () {
                   setState(task.toggleDone);
-                  _storageService.saveTaskList(_tasks);
+                  _saveTasks();
                 },
                 onMove: (dest) => _moveTask(pageIndex, index, dest),
                 onMoveNext: () => _moveTaskToNextPage(pageIndex, index),

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -197,7 +197,7 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _updateHomeWidget() async {
-    final data = _tasks.map((t) => t.title).join('\n');
+    final data = _tasks.map((t) => '• ${t.title}').join('\n');
     try {
       await HomeWidget.saveWidgetData(dataKey, data);
       await HomeWidget.updateWidget(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   path_provider: ^2.1.2
   flutter_markdown: ^0.6.10
+  home_widget: ^0.4.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   path_provider: ^2.1.2
   flutter_markdown: ^0.6.10
-  home_widget: ^0.4.4
+  home_widget: ^0.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `home_widget` dependency
- push task titles to HomeWidget and refresh widget when tasks change

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6aec29310832b9e5cd33ae9f0e859