### PR TITLE
feat(android): include version in release APK name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.14] - 2025-08-21
+- rename release APK to include app version
+
 ## [0.1.13] - 2025-08-21
 - dont show tasks that are done in the widget.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+import com.android.build.api.variant.VariantOutputConfiguration
 
 plugins {
     id("com.android.application")
@@ -45,15 +45,16 @@ android {
     }
 }
 
-android.applicationVariants.all {
-    if (buildType.name == "release") {
-        outputs
-            .map { it as BaseVariantOutputImpl }
-            .forEach { output ->
-                val version = versionName
-                val type = buildType.name
-                output.outputFileName = "app-${type}_v${version}.apk"
+
+androidComponents {
+    onVariants(selector().withBuildType("release")) { variant ->
+        variant.outputs.forEach { output ->
+            if (output.outputType == VariantOutputConfiguration.OutputType.SINGLE) {
+                val version = variant.versionName.get()
+                val type = variant.buildType
+                output.outputFileName.set("app-${type}_v${version}.apk")
             }
+        }
     }
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -40,6 +42,18 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+android.applicationVariants.all {
+    if (buildType.name == "release") {
+        outputs
+            .map { it as BaseVariantOutputImpl }
+            .forEach { output ->
+                val version = versionName
+                val type = buildType.name
+                output.outputFileName = "app-${type}_v${version}.apk"
+            }
     }
 }
 

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -6,7 +6,7 @@ class Config {
   static const bool isDev = !bool.fromEnvironment('dart.vm.product');
 
   /// Current application version.
-  static const String version = '0.1.13';
+  static const String version = '0.1.14';
 
   static const List<String> initialTasks = [
     'Get milk',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: best_todo_2
 description: A simple Flutter to-do application
 publish_to: 'none'
-version: 0.1.13
+version: 0.1.14
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Summary
- rename release APK to include app version, e.g. `app-release_v0.1.13.apk`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cb1fbbf8832ba0a813fb8de90f80