### PR TITLE
Filter home widget tasks by due date

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -197,10 +197,16 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _updateHomeWidget() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
     final data = _tasks
-      .where((t) => !t.isDone) // keep only tasks that are not done
-      .map((t) => '• ${t.title}')
-      .join('\n');
+        .where((t) {
+          if (t.dueDate == null) return false;
+          final due = DateTime(t.dueDate!.year, t.dueDate!.month, t.dueDate!.day);
+          return !t.isDone && !due.isAfter(today);
+        }) // keep only pending tasks due today or earlier
+        .map((t) => '• ${t.title}')
+        .join('\n');
 
     try {
       await HomeWidget.saveWidgetData(dataKey, data);


### PR DESCRIPTION
## Summary
- only show pending tasks due today or earlier on the home widget

## Testing
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d09abe0c832b83f64309fad59e01