### PR TITLE
Exclude tomorrow tasks from today list

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -11,6 +11,7 @@ import 'settings_page.dart';
 import 'deleted_items_page.dart';
 import 'changelog_page.dart';
 import 'app_logs_page.dart';
+import '../utils/date_utils.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -224,7 +225,10 @@ class _HomePageState extends State<HomePage>
   List<Task> _tasksForTab(int pageIndex) {
     return _tasks.where((task) {
       if (task.dueDate == null) return false;
-      final diff = task.dueDate!.difference(_currentDate).inDays;
+      // Compare dates without considering the time of day so that tasks due
+      // tomorrow don't appear in today's list simply because they are less
+      // than 24 hours away.
+      final diff = dateDiffInDays(task.dueDate!, _currentDate);
       if (pageIndex == 0) return diff <= 0;
       if (pageIndex == 1) return diff == 1;
       if (pageIndex == 2) return diff == 2;

--- a/lib/utils/date_utils.dart
+++ b/lib/utils/date_utils.dart
@@ -1,0 +1,5 @@
+int dateDiffInDays(DateTime from, DateTime to) {
+  final fromDate = DateTime(from.year, from.month, from.day);
+  final toDate = DateTime(to.year, to.month, to.day);
+  return fromDate.difference(toDate).inDays;
+}

--- a/test/home_page_task_filter_test.dart
+++ b/test/home_page_task_filter_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:best_todo_2/models/task.dart';
+import 'package:best_todo_2/utils/date_utils.dart';
+
+void main() {
+  test('tasks due tomorrow are not included in today list', () {
+    final now = DateTime(2024, 5, 3, 23); // May 3, 11PM
+    final tasks = [
+      Task(title: 'today', dueDate: DateTime(2024, 5, 3, 10)),
+      Task(title: 'tomorrow', dueDate: DateTime(2024, 5, 4, 9)),
+    ];
+
+    final todayTasks = tasks.where((task) {
+      final diff = dateDiffInDays(task.dueDate!, now);
+      return diff <= 0;
+    }).toList();
+
+    expect(todayTasks.length, 1);
+    expect(todayTasks.first.title, 'today');
+  });
+
+  test('dateDiffInDays ignores the time of day', () {
+    final now = DateTime(2024, 5, 3, 23);
+    final tomorrowMorning = DateTime(2024, 5, 4, 1);
+    expect(dateDiffInDays(tomorrowMorning, now), 1);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure task tab filtering compares dates only
- add `dateDiffInDays` helper
- test that tomorrow tasks are excluded from today's list

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fa6dc054832b9078affc7d0541e1