### PR TITLE
Move checked tasks to end of list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.15] - 2025-08-21
+- completed tasks now move to the end of their list when checked.
+
 ## [0.1.14] - 2025-08-21
 - only show pending tasks due today or earlier on the home widget.
 - update padding in widget layout to improve appearance on various devices.

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -6,7 +6,7 @@ class Config {
   static const bool isDev = !bool.fromEnvironment('dart.vm.product');
 
   /// Current application version.
-  static const String version = '0.1.15';
+  static const String version = '0.1.16';
 
   static const List<String> initialTasks = [
     'Get milk',

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -6,7 +6,7 @@ class Config {
   static const bool isDev = !bool.fromEnvironment('dart.vm.product');
 
   /// Current application version.
-  static const String version = '0.1.14';
+  static const String version = '0.1.15';
 
   static const List<String> initialTasks = [
     'Get milk',

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -265,7 +265,14 @@ class _HomePageState extends State<HomePage>
               final tile = TaskTile(
                 task: task,
                 onChanged: () {
-                  setState(task.toggleDone);
+                  setState(() {
+                    task.toggleDone();
+                    if (task.isDone) {
+                      _tasks
+                        ..remove(task)
+                        ..add(task);
+                    }
+                  });
                   _saveTasks();
                 },
                 onMove: (dest) => _moveTask(pageIndex, index, dest),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: best_todo_2
 description: A simple Flutter to-do application
 publish_to: 'none'
-version: 0.1.14
+version: 0.1.15
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: best_todo_2
 description: A simple Flutter to-do application
 publish_to: 'none'
-version: 0.1.15
+version: 0.1.16
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Summary
- move checked tasks to end of list
- bump version to 0.1.15 and update changelog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ee477790832b8a87b9b410dbb833