### PR TITLE
Show log delete button only on emulators

### DIFF
--- a/lib/ui/app_logs_page.dart
+++ b/lib/ui/app_logs_page.dart
@@ -1,10 +1,45 @@
+import 'dart:io' show Platform;
+
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 
 import '../services/log_service.dart';
 
 /// Displays logs collected during app interactions and widget updates.
-class AppLogsPage extends StatelessWidget {
+class AppLogsPage extends StatefulWidget {
   const AppLogsPage({Key? key}) : super(key: key);
+
+  @override
+  State<AppLogsPage> createState() => _AppLogsPageState();
+}
+
+class _AppLogsPageState extends State<AppLogsPage> {
+  bool _showDelete = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkEmulator();
+  }
+
+  Future<void> _checkEmulator() async {
+    final deviceInfo = DeviceInfoPlugin();
+    bool show = false;
+    try {
+      if (Platform.isAndroid) {
+        final info = await deviceInfo.androidInfo;
+        show = !info.isPhysicalDevice;
+      } else if (Platform.isIOS) {
+        final info = await deviceInfo.iosInfo;
+        show = !info.isPhysicalDevice;
+      }
+    } catch (_) {
+      show = false;
+    }
+    if (mounted) {
+      setState(() => _showDelete = show);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,11 +60,13 @@ class AppLogsPage extends StatelessWidget {
           );
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: LogService.clear,
-        tooltip: 'Clear logs',
-        child: const Icon(Icons.delete),
-      ),
+      floatingActionButton: _showDelete
+          ? FloatingActionButton(
+              onPressed: LogService.clear,
+              tooltip: 'Clear logs',
+              child: const Icon(Icons.delete),
+            )
+          : null,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   path_provider: ^2.1.2
   flutter_markdown: ^0.6.10
   home_widget: ^0.8.0
+  device_info_plus: ^9.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `device_info_plus` to check device environment
- hide log clear button on physical devices

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a717355754832b851909b7e567ffba