### PR TITLE
Allow adjusting default delay

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,5 +1,8 @@
 class Config {
-  static const int defaultDelaySeconds = 5;
+  static double defaultDelaySeconds = 5.0;
+
+  static Duration get delayDuration =>
+      Duration(milliseconds: (defaultDelaySeconds * 1000).round());
 
   /// Whether the app is running in development mode.
   /// Uses the `dart.vm.product` flag to detect production builds.

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -135,7 +135,7 @@ class _HomePageState extends State<HomePage>
     LogService.add('HomePage._deleteTask', 'Deleted "${task.title}"');
 
     late Timer timer;
-    timer = Timer(const Duration(seconds: Config.defaultDelaySeconds), () {
+    timer = Timer(Config.delayDuration, () {
       setState(() {
         _deletedTasks.insert(0, task);
         if (_deletedTasks.length > 100) {
@@ -149,7 +149,7 @@ class _HomePageState extends State<HomePage>
       ..showSnackBar(
         SnackBar(
           content: Text('Deleted "${task.title}"'),
-          duration: const Duration(seconds: Config.defaultDelaySeconds),
+          duration: Config.delayDuration,
           action: SnackBarAction(
             label: 'Cancel',
             onPressed: () {

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -14,6 +14,7 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _notifications = false;
   bool _swipeLeftDelete = Config.swipeLeftDelete;
   bool _darkMode = Config.darkMode;
+  double _defaultDelaySeconds = Config.defaultDelaySeconds;
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +45,22 @@ class _SettingsPageState extends State<SettingsPage> {
               Config.swipeLeftDelete = val;
               widget.onSettingsChanged?.call();
             },
+          ),
+          ListTile(
+            title: Text(
+                'Default delay (${_defaultDelaySeconds.toStringAsFixed(1)}s)'),
+            subtitle: Slider(
+              value: _defaultDelaySeconds,
+              min: 0,
+              max: 10,
+              divisions: 100,
+              onChanged: (val) {
+                final newVal = (val * 10).round() / 10;
+                setState(() => _defaultDelaySeconds = newVal);
+                Config.defaultDelaySeconds = newVal;
+                widget.onSettingsChanged?.call();
+              },
+            ),
           ),
         ],
       ),

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -55,7 +55,7 @@ class _TaskTileState extends State<TaskTile>
     _labelController = TextEditingController(text: widget.task.label);
     _progressController = AnimationController(
       vsync: this,
-      duration: Duration(seconds: Config.defaultDelaySeconds),
+      duration: Config.delayDuration,
     );
     _destinations = List<int>.generate(Config.tabs.length, (i) => i)
       ..remove(widget.pageIndex);
@@ -86,7 +86,7 @@ class _TaskTileState extends State<TaskTile>
     _timer?.cancel();
     _progressController.reset();
     _progressController.forward();
-    _timer = Timer(Duration(seconds: Config.defaultDelaySeconds), () {
+    _timer = Timer(Config.delayDuration, () {
       if (mounted && _showOptions) {
         widget.onMoveNext();
         _progressController.stop();


### PR DESCRIPTION
## Summary
- Make default task delay configurable in Settings with 0.1s increments
- Expose configurable delay in `Config` and update timers to use it

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a728ca1f68832b98374edac9dfcc92