### PR TITLE
feat: add setting for tab icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.23] - 2025-08-21
+- Added icons for unselected tabs.
+- added settings to toggle icon tabs.
+
 ## [0.1.22] - 2025-08-21
 - widen the tabs.
 - added icons in background ready to be used in next version

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -37,4 +37,8 @@ class Config {
 
   /// If true, the app uses a dark color scheme.
   static bool darkMode = false;
+
+  /// If true, the tab bar shows icons for unselected tabs.
+  /// When false, all tabs display text labels only.
+  static bool useIconTabs = false;
 }

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -9,7 +9,7 @@ class Config {
   static const bool isDev = !bool.fromEnvironment('dart.vm.product');
 
   /// Current application version.
-  static const String version = '0.1.22';
+  static const String version = '0.1.23';
 
   static const List<String> initialTasks = [
     'Get milk',

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -416,20 +416,20 @@ class _HomePageState extends State<HomePage>
               TabBar(
                 controller: _tabController,
                 labelPadding: const EdgeInsets.symmetric(horizontal: 1),
-                tabs: Config.tabs.map((t) => Tab(text: t)).toList(),
-
-                // tabs: List.generate(Config.tabs.length, (index) {
-                //   final selected = _tabController.index == index;
-                //   if (selected) {
-                //     return Tab(text: Config.tabs[index]);
-                //   }
-                //   return Tab(
-                //     icon: Image.asset(
-                //       _tabIconPaths[index],
-                //       height: 24,
-                //     ),
-                //   );
-                // }),
+                tabs: Config.useIconTabs
+                    ? List.generate(Config.tabs.length, (index) {
+                        final selected = _tabController.index == index;
+                        if (selected) {
+                          return Tab(text: Config.tabs[index]);
+                        }
+                        return Tab(
+                          icon: Image.asset(
+                            _tabIconPaths[index],
+                            height: 24,
+                          ),
+                        );
+                      })
+                    : Config.tabs.map((t) => Tab(text: t)).toList(),
               ),
             ],
           ),

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -14,6 +14,7 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _notifications = false;
   bool _swipeLeftDelete = Config.swipeLeftDelete;
   bool _darkMode = Config.darkMode;
+  bool _useIconTabs = Config.useIconTabs;
   double _defaultDelaySeconds = Config.defaultDelaySeconds;
 
   @override
@@ -43,6 +44,15 @@ class _SettingsPageState extends State<SettingsPage> {
             onChanged: (val) {
               setState(() => _swipeLeftDelete = val);
               Config.swipeLeftDelete = val;
+              widget.onSettingsChanged?.call();
+            },
+          ),
+          SwitchListTile(
+            title: const Text('Use tab icons'),
+            value: _useIconTabs,
+            onChanged: (val) {
+              setState(() => _useIconTabs = val);
+              Config.useIconTabs = val;
               widget.onSettingsChanged?.call();
             },
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: best_todo_2
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.22
+version: 0.1.23
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Summary
- allow users to toggle between text-only tabs and icon tabs
- expose switch for tab icons in Settings page
- use new configuration to show icons for unselected tabs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a745df7860832bbc0c325f78ea03c2