### PR TITLE
Persist settings across app restarts

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,3 +1,8 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
 class Config {
   static double defaultDelaySeconds = 5.0;
 
@@ -38,7 +43,51 @@ class Config {
   /// If true, the app uses a dark color scheme.
   static bool darkMode = false;
 
+  /// If true, notifications are enabled.
+  static bool enableNotifications = false;
+
   /// If true, the tab bar shows icons for unselected tabs.
   /// When false, all tabs display text labels only.
   static bool useIconTabs = false;
+
+  static const _settingsFileName = 'settings.json';
+
+  static Future<File> _getSettingsFile() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/$_settingsFileName');
+  }
+
+  /// Loads persisted settings from disk.
+  static Future<void> load() async {
+    try {
+      final file = await _getSettingsFile();
+      if (await file.exists()) {
+        final data =
+            jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+        swipeLeftDelete = data['swipeLeftDelete'] ?? swipeLeftDelete;
+        darkMode = data['darkMode'] ?? darkMode;
+        enableNotifications =
+            data['enableNotifications'] ?? enableNotifications;
+        useIconTabs = data['useIconTabs'] ?? useIconTabs;
+        defaultDelaySeconds =
+            (data['defaultDelaySeconds'] as num?)?.toDouble() ??
+                defaultDelaySeconds;
+      }
+    } catch (_) {}
+  }
+
+  /// Persists the current settings to disk.
+  static Future<void> save() async {
+    try {
+      final file = await _getSettingsFile();
+      final data = {
+        'swipeLeftDelete': swipeLeftDelete,
+        'darkMode': darkMode,
+        'enableNotifications': enableNotifications,
+        'useIconTabs': useIconTabs,
+        'defaultDelaySeconds': defaultDelaySeconds,
+      };
+      await file.writeAsString(jsonEncode(data), flush: true);
+    } catch (_) {}
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,9 @@ import 'config.dart';
 
 const Color _seedColor = Color(0xFF005FDD);
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Config.load();
   runApp(const MyApp());
 }
 

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -11,7 +11,7 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  bool _notifications = false;
+  bool _notifications = Config.enableNotifications;
   bool _swipeLeftDelete = Config.swipeLeftDelete;
   bool _darkMode = Config.darkMode;
   bool _useIconTabs = Config.useIconTabs;
@@ -26,14 +26,19 @@ class _SettingsPageState extends State<SettingsPage> {
           SwitchListTile(
             title: const Text('Enable notifications'),
             value: _notifications,
-            onChanged: (val) => setState(() => _notifications = val),
+            onChanged: (val) async {
+              setState(() => _notifications = val);
+              Config.enableNotifications = val;
+              await Config.save();
+            },
           ),
           SwitchListTile(
             title: const Text('Dark mode'),
             value: _darkMode,
-            onChanged: (val) {
+            onChanged: (val) async {
               setState(() => _darkMode = val);
               Config.darkMode = val;
+              await Config.save();
               MyApp.of(context)?.updateTheme();
               widget.onSettingsChanged?.call();
             },
@@ -41,18 +46,20 @@ class _SettingsPageState extends State<SettingsPage> {
           SwitchListTile(
             title: const Text('Swipe left to delete'),
             value: _swipeLeftDelete,
-            onChanged: (val) {
+            onChanged: (val) async {
               setState(() => _swipeLeftDelete = val);
               Config.swipeLeftDelete = val;
+              await Config.save();
               widget.onSettingsChanged?.call();
             },
           ),
           SwitchListTile(
             title: const Text('Use tab icons'),
             value: _useIconTabs,
-            onChanged: (val) {
+            onChanged: (val) async {
               setState(() => _useIconTabs = val);
               Config.useIconTabs = val;
+              await Config.save();
               widget.onSettingsChanged?.call();
             },
           ),
@@ -64,10 +71,11 @@ class _SettingsPageState extends State<SettingsPage> {
               min: 0,
               max: 10,
               divisions: 100,
-              onChanged: (val) {
+              onChanged: (val) async {
                 final newVal = (val * 10).round() / 10;
                 setState(() => _defaultDelaySeconds = newVal);
                 Config.defaultDelaySeconds = newVal;
+                await Config.save();
                 widget.onSettingsChanged?.call();
               },
             ),

--- a/test/config_persistence_test.dart
+++ b/test/config_persistence_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'package:best_todo_2/config.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+void main() {
+  test('Config persists settings to disk', () async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+
+    // Set and save custom values
+    Config.darkMode = true;
+    Config.swipeLeftDelete = false;
+    Config.useIconTabs = true;
+    Config.enableNotifications = true;
+    Config.defaultDelaySeconds = 7.5;
+    await Config.save();
+
+    // Reset to defaults
+    Config.darkMode = false;
+    Config.swipeLeftDelete = true;
+    Config.useIconTabs = false;
+    Config.enableNotifications = false;
+    Config.defaultDelaySeconds = 5.0;
+
+    await Config.load();
+
+    expect(Config.darkMode, isTrue);
+    expect(Config.swipeLeftDelete, isFalse);
+    expect(Config.useIconTabs, isTrue);
+    expect(Config.enableNotifications, isTrue);
+    expect(Config.defaultDelaySeconds, 7.5);
+  });
+}


### PR DESCRIPTION
## Summary
- load and save user preferences from a settings file
- update SettingsPage to persist selections and main to load them
- add a unit test verifying Config persistence

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f2e1ae6c832ba7d7a80281549aa4