### PR TITLE
Add introduction screens

### DIFF
--- a/lib/ui/intro_page.dart
+++ b/lib/ui/intro_page.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+class IntroPage extends StatefulWidget {
+  final VoidCallback onFinished;
+  const IntroPage({super.key, required this.onFinished});
+
+  @override
+  State<IntroPage> createState() => _IntroPageState();
+}
+
+class _IntroPageState extends State<IntroPage> {
+  final PageController _controller = PageController();
+  int _currentIndex = 0;
+
+  void _nextPage() {
+    if (_currentIndex < 2) {
+      _controller.nextPage(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    } else {
+      widget.onFinished();
+    }
+  }
+
+  Widget _buildPage(String title, String body, IconData icon) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 72),
+          const SizedBox(height: 24),
+          Text(
+            title,
+            style: Theme.of(context).textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            body,
+            style: Theme.of(context).textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = [
+      _buildPage(
+        'Privacy First',
+        'No ads, no tracking. Your data stays on your device.',
+        Icons.lock,
+      ),
+      _buildPage(
+        'Open Source & Fast',
+        'Transparent code and boots in under one second.',
+        Icons.speed,
+      ),
+      _buildPage(
+        'Minimal Interactions',
+        'Designed for the fewest clicks possible.',
+        Icons.touch_app,
+      ),
+    ];
+
+    return Scaffold(
+      body: PageView(
+        controller: _controller,
+        onPageChanged: (index) => setState(() => _currentIndex = index),
+        children: pages,
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: List.generate(pages.length, (index) {
+                return Container(
+                  width: 8,
+                  height: 8,
+                  margin: const EdgeInsets.symmetric(horizontal: 4),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _currentIndex == index
+                        ? Theme.of(context).colorScheme.primary
+                        : Colors.grey,
+                  ),
+                );
+              }),
+            ),
+            TextButton(
+              onPressed: _nextPage,
+              child: Text(_currentIndex == pages.length - 1 ? 'Get Started' : 'Next'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_markdown: ^0.6.10
   home_widget: ^0.8.0
   device_info_plus: ^9.0.2
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add three-page introduction highlighting privacy, open source, and minimal interactions
- show intro sequence before the configured start page
- persist intro completion so the screens appear only once

## Testing
- `dart format lib/main.dart lib/ui/intro_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f504b5a8832b8d9a8a7d457cf13f