### PR TITLE
Ensure task edits update correct item

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -281,6 +281,7 @@ class _HomePageState extends State<HomePage>
               final task = tasks[index];
               final isAndroid = Theme.of(context).platform == TargetPlatform.android;
               final tile = TaskTile(
+                key: ValueKey(task),
                 task: task,
                 onChanged: () {
                   setState(() {
@@ -293,6 +294,10 @@ class _HomePageState extends State<HomePage>
                   });
                   _saveTasks();
                 },
+                onUpdate: () {
+                  setState(() {});
+                  _saveTasks();
+                },
                 onMove: (dest) => _moveTask(pageIndex, index, dest),
                 onMoveNext: () => _moveTaskToNextPage(pageIndex, index),
                 onDelete: () => _deleteTask(pageIndex, index),
@@ -303,7 +308,7 @@ class _HomePageState extends State<HomePage>
               return isAndroid
                   ? tile
                   : Dismissible(
-                      key: ValueKey('${task.title}-$index-$pageIndex'),
+                      key: ValueKey(task),
                       background: Container(
                         color: Colors.greenAccent.withOpacity(0.5),
                       ),

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -10,6 +10,7 @@ import '../config.dart';
 class TaskTile extends StatefulWidget {
   final Task task;
   final VoidCallback onChanged;
+  final VoidCallback onUpdate;
   final void Function(int destination) onMove;
   final VoidCallback onMoveNext;
   final VoidCallback onDelete;
@@ -21,6 +22,7 @@ class TaskTile extends StatefulWidget {
     Key? key,
     required this.task,
     required this.onChanged,
+    required this.onUpdate,
     required this.onMove,
     required this.onMoveNext,
     required this.onDelete,
@@ -215,7 +217,7 @@ class _TaskTileState extends State<TaskTile>
                 children: [
                   Focus(
                     onFocusChange: (hasFocus) {
-                      if (!hasFocus) widget.onChanged();
+                      if (!hasFocus) widget.onUpdate();
                     },
                     child: TextField(
                       controller: _titleController,
@@ -225,7 +227,7 @@ class _TaskTileState extends State<TaskTile>
                   ),
                   Focus(
                     onFocusChange: (hasFocus) {
-                      if (!hasFocus) widget.onChanged();
+                      if (!hasFocus) widget.onUpdate();
                     },
                     child: TextField(
                       controller: _descController,
@@ -237,7 +239,7 @@ class _TaskTileState extends State<TaskTile>
                   ),
                   Focus(
                     onFocusChange: (hasFocus) {
-                      if (!hasFocus) widget.onChanged();
+                      if (!hasFocus) widget.onUpdate();
                     },
                     child: TextField(
                       controller: _noteController,
@@ -249,7 +251,7 @@ class _TaskTileState extends State<TaskTile>
                   ),
                   Focus(
                     onFocusChange: (hasFocus) {
-                      if (!hasFocus) widget.onChanged();
+                      if (!hasFocus) widget.onUpdate();
                     },
                     child: TextField(
                       controller: _labelController,
@@ -274,6 +276,7 @@ class _TaskTileState extends State<TaskTile>
                           );
                           if (picked != null) {
                             setState(() => widget.task.dueDate = picked);
+                            widget.onUpdate();
                           }
                         },
                         child: const Text('Pick due date'),


### PR DESCRIPTION
## Summary
- assign stable keys to TaskTile and its Dismissible wrapper
- add onUpdate callback so edits to a task refresh and persist

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a80ad381bc832b9762c3e11e9ba840