### PR TITLE
Refresh home widget after task changes

### DIFF
--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -9,7 +9,7 @@ import '../config.dart';
 
 class TaskTile extends StatefulWidget {
   final Task task;
-  final VoidCallback onChanged;
+  final Future<void> Function() onChanged;
   final void Function(int destination) onMove;
   final VoidCallback onMoveNext;
   final VoidCallback onDelete;
@@ -153,7 +153,7 @@ class _TaskTileState extends State<TaskTile>
       minLeadingWidth: isAndroid ? 0 : null,
       leading: Checkbox(
         value: widget.task.isDone,
-        onChanged: (_) => setState(() => widget.onChanged()),
+        onChanged: (_) => widget.onChanged(),
       ),
       title: Text(
         widget.task.title,
@@ -274,6 +274,7 @@ class _TaskTileState extends State<TaskTile>
                           );
                           if (picked != null) {
                             setState(() => widget.task.dueDate = picked);
+                            widget.onChanged();
                           }
                         },
                         child: const Text('Pick due date'),


### PR DESCRIPTION
## Summary
- Await task saves and widget refreshes so the home screen widget stays in sync
- Allow task tiles to handle async change callbacks so completing, moving, or deleting tasks updates the widget

## Testing
- `dart format lib/ui/home_page.dart lib/ui/task_tile.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a85039b78c832baa68edee9043e46f