### PR TITLE
Enable folder export on macOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.32] - 2025-08-22
+- request storage permission before exporting tasks on Android
+
+## [0.1.31] - 2025-08-22
+- allow selecting a folder when exporting tasks in sandboxed macOS builds.
+
 ## [0.1.30] - 2025-08-22
 - add update button on about page to check for new versions.
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <application
         android:label="BestToDo"
         android:name="${applicationName}"

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -14,7 +14,7 @@ class Config {
   static const bool isDev = !bool.fromEnvironment('dart.vm.product');
 
   /// Current application version.
-  static const String version = '0.1.30';
+  static const String version = '0.1.32';
 
   static const List<String> initialTasks = [
     'Get milk',

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -5,6 +5,7 @@ import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:home_widget/home_widget.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../config.dart';
 import '../models/task.dart';
@@ -237,6 +238,15 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _exportTasks() async {
+    if (Platform.isAndroid) {
+      final status = await Permission.storage.request();
+      if (!status.isGranted) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Storage permission denied')));
+        return;
+      }
+    }
     final downloadsDir = await getDownloadsDirectory();
     final now = DateTime.now();
     final ts =

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,7 +6,9 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
+        <key>com.apple.security.network.server</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.30+4
+version: 0.1.32+6
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -18,6 +18,7 @@ dependencies:
   device_info_plus: ^9.0.2
   shared_preferences: ^2.2.2
   file_selector: ^1.0.0
+  permission_handler: ^11.3.1
   url_launcher: ^6.2.5
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.32+6
+version: 0.1.32+5
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Summary
- request external storage permission on Android before saving task exports
- allow selecting a folder when exporting tasks in sandboxed macOS builds
- bump version to 0.1.32

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa2c0ec8832bb6932f06d2b50852