### PR TITLE
Add unique task IDs and list ranking

### DIFF
--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,4 +1,8 @@
 class Task {
+  /// Unique identifier for the task. Generated automatically when a task is
+  /// created or imported without an id.
+  String id;
+
   String title;
   String description;
   String note;
@@ -6,14 +10,36 @@ class Task {
   DateTime? dueDate;
   bool isDone;
 
+  /// Position of the task within its list. This value is optional and not
+  /// required to be unique. It is updated based on the task's position in the
+  /// UI lists.
+  int? listRanking;
+
   Task({
+    String? id,
     required this.title,
     this.description = '',
     this.note = '',
     this.label = '',
     this.dueDate,
     this.isDone = false,
-  });
+    this.listRanking,
+  }) : id = id ?? generateId();
+
+  /// Generates a pseudo-unique identifier based on the current timestamp.
+  static String generateId() => DateTime.now().microsecondsSinceEpoch.toString();
+
+  /// Ensures that every task in the provided list has a unique id. Tasks with
+  /// missing or duplicate ids are assigned new ones.
+  static void ensureUniqueIds(List<Task> tasks) {
+    final ids = <String>{};
+    for (final task in tasks) {
+      if (task.id.isEmpty || ids.contains(task.id)) {
+        task.id = generateId();
+      }
+      ids.add(task.id);
+    }
+  }
 
   void toggleDone() {
     isDone = !isDone;
@@ -21,6 +47,7 @@ class Task {
 
   factory Task.fromJson(Map<String, dynamic> json) {
     return Task(
+      id: json['id'] as String?,
       title: json['title'] as String? ?? '',
       description: json['description'] as String? ?? '',
       note: json['note'] as String? ?? '',
@@ -29,15 +56,18 @@ class Task {
           ? DateTime.parse(json['dueDate'] as String)
           : null,
       isDone: json['isDone'] as bool? ?? false,
+      listRanking: json['listRanking'] as int?,
     );
   }
 
   Map<String, dynamic> toJson() => {
+        'id': id,
         'title': title,
         'description': description,
         'note': note,
         'label': label,
         'dueDate': dueDate?.toIso8601String(),
         'isDone': isDone,
+        if (listRanking != null) 'listRanking': listRanking,
       };
 }

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -59,6 +59,7 @@ class StorageService {
       final tasks = data
           .map((e) => Task.fromJson(e as Map<String, dynamic>))
           .toList();
+      Task.ensureUniqueIds(tasks);
       if (isNewDay) {
         tasks.removeWhere((t) => t.isDone);
         await saveTaskList(tasks);
@@ -86,9 +87,11 @@ class StorageService {
       if (!await file.exists()) return <Task>[];
       final contents = await file.readAsString();
       final List<dynamic> data = jsonDecode(contents);
-      return data
+      final tasks = data
           .map((e) => Task.fromJson(e as Map<String, dynamic>))
           .toList();
+      Task.ensureUniqueIds(tasks);
+      return tasks;
     } catch (_) {
       return <Task>[];
     }

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -231,7 +231,14 @@ class _HomePageState extends State<HomePage>
     } catch (_) {}
   }
 
+  void _updateListRankings() {
+    for (var i = 0; i < Config.tabs.length; i++) {
+      _tasksForTab(i); // _tasksForTab assigns listRanking
+    }
+  }
+
   void _saveTasks() {
+    _updateListRankings();
     _storageService.saveTaskList(_tasks);
     _updateHomeWidget();
   }
@@ -280,7 +287,7 @@ class _HomePageState extends State<HomePage>
 
   /// Returns the list of tasks that should appear on the given tab index.
   List<Task> _tasksForTab(int pageIndex) {
-    return _tasks.where((task) {
+    final filtered = _tasks.where((task) {
       if (task.dueDate == null) return false;
       // Compare dates without considering the time of day so that tasks due
       // tomorrow don't appear in today's list simply because they are less
@@ -292,6 +299,11 @@ class _HomePageState extends State<HomePage>
       if (pageIndex == 3) return diff >= 3 && diff < 30;
       return diff >= 30;
     }).toList();
+
+    for (var i = 0; i < filtered.length; i++) {
+      filtered[i].listRanking = i + 1;
+    }
+    return filtered;
   }
 
   Widget _buildTaskList(int pageIndex) {
@@ -348,7 +360,7 @@ class _HomePageState extends State<HomePage>
               return isAndroid
                   ? tile
                   : Dismissible(
-                      key: ValueKey('${task.title}-$index-$pageIndex'),
+                      key: ValueKey(task.id),
                       background: Container(
                         color: Colors.greenAccent.withOpacity(0.5),
                       ),

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:convert';
 
 import 'package:best_todo_2/models/task.dart';
 import 'package:best_todo_2/services/storage_service.dart';
@@ -32,5 +33,22 @@ void main() {
     final loaded = await service.loadTaskList();
     expect(loaded.length, 1);
     expect(loaded.first.title, 'pending');
+  });
+
+  test('importTaskList assigns unique ids to imported tasks', () async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    final file = File('${tempDir.path}/import.json');
+    final data = [
+      {'title': 'a', 'id': 'same'},
+      {'title': 'b', 'id': 'same'}, // duplicate id
+      {'title': 'c'}, // missing id
+    ];
+    await file.writeAsString(jsonEncode(data));
+
+    final service = StorageService();
+    final imported = await service.importTaskList(file.path);
+
+    final ids = imported.map((t) => t.id).toSet();
+    expect(ids.length, imported.length); // all ids are unique
   });
 }

--- a/test/task_model_test.dart
+++ b/test/task_model_test.dart
@@ -8,4 +8,16 @@ void main() {
     task.toggleDone();
     expect(task.isDone, isTrue);
   });
+
+  test('tasks generate unique ids and preserve them through serialization', () {
+    final task1 = Task(title: 'A');
+    final task2 = Task(title: 'B');
+    expect(task1.id, isNotEmpty);
+    expect(task2.id, isNotEmpty);
+    expect(task1.id, isNot(task2.id));
+
+    final json = task1.toJson();
+    final restored = Task.fromJson(json);
+    expect(restored.id, task1.id);
+  });
 }


### PR DESCRIPTION
## Summary
- assign auto-generated unique IDs and optional list rankings to tasks
- ensure storage/import routines regenerate missing or duplicate task IDs
- update UI to maintain list rankings and use persistent task IDs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac037f3118832bb6d60df2284a0fff