### PR TITLE
feat: add unique task ids and list ranking

### DIFF
--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,19 +1,29 @@
+import 'package:uuid/uuid.dart';
+
 class Task {
+  static final Uuid _uuid = const Uuid();
+
+  static String newUid() => _uuid.v4();
+
+  String uid;
   String title;
   String description;
   String note;
   String label;
   DateTime? dueDate;
   bool isDone;
+  int? listRanking;
 
   Task({
+    String? uid,
     required this.title,
     this.description = '',
     this.note = '',
     this.label = '',
     this.dueDate,
     this.isDone = false,
-  });
+    this.listRanking,
+  }) : uid = uid ?? Task.newUid();
 
   void toggleDone() {
     isDone = !isDone;
@@ -21,6 +31,7 @@ class Task {
 
   factory Task.fromJson(Map<String, dynamic> json) {
     return Task(
+      uid: json['uid'] as String?,
       title: json['title'] as String? ?? '',
       description: json['description'] as String? ?? '',
       note: json['note'] as String? ?? '',
@@ -29,15 +40,18 @@ class Task {
           ? DateTime.parse(json['dueDate'] as String)
           : null,
       isDone: json['isDone'] as bool? ?? false,
+      listRanking: json['listRanking'] as int?,
     );
   }
 
   Map<String, dynamic> toJson() => {
+        'uid': uid,
         'title': title,
         'description': description,
         'note': note,
         'label': label,
         'dueDate': dueDate?.toIso8601String(),
         'isDone': isDone,
+        if (listRanking != null) 'listRanking': listRanking,
       };
 }

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -9,6 +9,16 @@ class StorageService {
   static const _fileName = 'tasks.json';
   static const _dateFileName = 'last_opened.txt';
 
+  void _ensureUniqueIds(List<Task> tasks) {
+    final ids = <String>{};
+    for (final t in tasks) {
+      if (t.uid.isEmpty || ids.contains(t.uid)) {
+        t.uid = Task.newUid();
+      }
+      ids.add(t.uid);
+    }
+  }
+
   Future<File> _getLocalFile() async {
     final dir = await getApplicationDocumentsDirectory();
     return File('${dir.path}/$_fileName');
@@ -59,6 +69,7 @@ class StorageService {
       final tasks = data
           .map((e) => Task.fromJson(e as Map<String, dynamic>))
           .toList();
+      _ensureUniqueIds(tasks);
       if (isNewDay) {
         tasks.removeWhere((t) => t.isDone);
         await saveTaskList(tasks);
@@ -86,9 +97,11 @@ class StorageService {
       if (!await file.exists()) return <Task>[];
       final contents = await file.readAsString();
       final List<dynamic> data = jsonDecode(contents);
-      return data
+      final tasks = data
           .map((e) => Task.fromJson(e as Map<String, dynamic>))
           .toList();
+      _ensureUniqueIds(tasks);
+      return tasks;
     } catch (_) {
       return <Task>[];
     }

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -136,6 +136,22 @@ class _HomePageState extends State<HomePage>
         'HomePage._moveTask', 'Moved "${task.title}" to page $destination');
   }
 
+  void _reorderTask(int pageIndex, int oldIndex, int newIndex) {
+    final tasks = _tasksForTab(pageIndex);
+    if (oldIndex >= tasks.length || newIndex > tasks.length) return;
+    setState(() {
+      if (newIndex > oldIndex) newIndex -= 1;
+      final task = tasks.removeAt(oldIndex);
+      tasks.insert(newIndex, task);
+      for (var i = 0; i < tasks.length; i++) {
+        tasks[i].listRanking = i + 1;
+      }
+    });
+    _saveTasks();
+    LogService.add('HomePage._reorderTask',
+        'Reordered task to position ${newIndex + 1} on page $pageIndex');
+  }
+
   void _deleteTask(int pageIndex, int index) {
     final tasks = _tasksForTab(pageIndex);
     if (index >= tasks.length) return;
@@ -286,7 +302,7 @@ class _HomePageState extends State<HomePage>
 
   /// Returns the list of tasks that should appear on the given tab index.
   List<Task> _tasksForTab(int pageIndex) {
-    return _tasks.where((task) {
+    final list = _tasks.where((task) {
       if (task.dueDate == null) return false;
       // Compare dates without considering the time of day so that tasks due
       // tomorrow don't appear in today's list simply because they are less
@@ -298,6 +314,9 @@ class _HomePageState extends State<HomePage>
       if (pageIndex == 3) return diff >= 3 && diff < 30;
       return diff >= 30;
     }).toList();
+    list.sort((a, b) => (a.listRanking ?? 1 << 31)
+        .compareTo(b.listRanking ?? 1 << 31));
+    return list;
   }
 
   Widget _buildTaskList(int pageIndex) {
@@ -325,13 +344,17 @@ class _HomePageState extends State<HomePage>
           ),
         ),
         Expanded(
-          child: ListView.builder(
+          child: ReorderableListView.builder(
             itemCount: tasks.length,
+            onReorder: (oldIndex, newIndex) =>
+                _reorderTask(pageIndex, oldIndex, newIndex),
+            buildDefaultDragHandles: true,
             itemBuilder: (context, index) {
               final task = tasks[index];
               final isAndroid =
                   Theme.of(context).platform == TargetPlatform.android;
               final tile = TaskTile(
+                key: isAndroid ? ValueKey(task.uid) : null,
                 task: task,
                 onChanged: () {
                   setState(() {
@@ -351,16 +374,17 @@ class _HomePageState extends State<HomePage>
                 showSwipeButton: !isAndroid,
                 swipeLeftDelete: Config.swipeLeftDelete,
               );
-              return isAndroid
-                  ? tile
-                  : Dismissible(
-                      key: ValueKey('${task.title}-$index-$pageIndex'),
-                      background: Container(
-                        color: Colors.greenAccent.withOpacity(0.5),
-                      ),
-                      onDismissed: (_) => _moveTaskToNextPage(pageIndex, index),
-                      child: tile,
-                    );
+              if (isAndroid) {
+                return tile;
+              }
+              return Dismissible(
+                key: ValueKey(task.uid),
+                background: Container(
+                  color: Colors.greenAccent.withOpacity(0.5),
+                ),
+                onDismissed: (_) => _moveTaskToNextPage(pageIndex, index),
+                child: tile,
+              );
             },
           ),
         )

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -72,7 +72,7 @@ class _HomePageState extends State<HomePage>
     if (mounted) {
       setState(() {});
     }
-    _updateHomeWidget();
+    _saveTasks();
   }
 
   @override
@@ -232,6 +232,12 @@ class _HomePageState extends State<HomePage>
   }
 
   void _saveTasks() {
+    for (var i = 0; i < Config.tabs.length; i++) {
+      final listTasks = _tasksForTab(i);
+      for (var j = 0; j < listTasks.length; j++) {
+        listTasks[j].listRanking = j + 1;
+      }
+    }
     _storageService.saveTaskList(_tasks);
     _updateHomeWidget();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   shared_preferences: ^2.2.2
   file_selector: ^1.0.0
   url_launcher: ^6.2.5
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:

--- a/test/reorder_test.dart
+++ b/test/reorder_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:best_todo_2/models/task.dart';
+
+void main() {
+  group('task reordering', () {
+    test('reordering updates list rankings', () {
+      final tasks = [
+        Task(title: 'a', listRanking: 1),
+        Task(title: 'b', listRanking: 2),
+        Task(title: 'c', listRanking: 3),
+      ];
+
+      // Simulate reorder from index 0 to 2 (move first to end)
+      final oldIndex = 0;
+      var newIndex = 2;
+      if (newIndex > oldIndex) newIndex -= 1;
+      final task = tasks.removeAt(oldIndex);
+      tasks.insert(newIndex, task);
+      for (var i = 0; i < tasks.length; i++) {
+        tasks[i].listRanking = i + 1;
+      }
+
+      expect(tasks.map((t) => t.title).toList(), ['b', 'c', 'a']);
+      expect(tasks[0].listRanking, 1);
+      expect(tasks[1].listRanking, 2);
+      expect(tasks[2].listRanking, 3);
+    });
+  });
+}

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:convert';
 
 import 'package:best_todo_2/models/task.dart';
 import 'package:best_todo_2/services/storage_service.dart';
@@ -32,5 +33,21 @@ void main() {
     final loaded = await service.loadTaskList();
     expect(loaded.length, 1);
     expect(loaded.first.title, 'pending');
+  });
+
+  test('importTaskList assigns unique ids when missing or duplicated', () async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    final file = File('${tempDir.path}/tasks.json');
+    final data = [
+      {'title': 'a', 'uid': 'same'},
+      {'title': 'b', 'uid': 'same'},
+      {'title': 'c'},
+    ];
+    await file.writeAsString(jsonEncode(data));
+    final service = StorageService();
+    final tasks = await service.importTaskList(file.path);
+    expect(tasks.length, 3);
+    final ids = tasks.map((t) => t.uid).toSet();
+    expect(ids.length, 3);
   });
 }

--- a/test/task_model_test.dart
+++ b/test/task_model_test.dart
@@ -8,4 +8,13 @@ void main() {
     task.toggleDone();
     expect(task.isDone, isTrue);
   });
+
+  test('tasks generate unique ids', () {
+    final a = Task(title: 'a');
+    final b = Task(title: 'b');
+    expect(a.uid, isNotEmpty);
+    expect(b.uid, isNotEmpty);
+    expect(a.uid, isNot(b.uid));
+    expect(a.listRanking, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- add automatically generated uid and optional list ranking to Task model
- ensure storage service generates new ids for duplicates or missing ones during load and import
- update home page to recompute list rankings before saving tasks
- cover new behavior with tests for unique id generation

## Testing
- `flutter pub get` (fails: command not found)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68ae10d970d8832bb3c32b90426b0f77