### PR TITLE
Ensure home widget task order matches app list

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -212,15 +212,8 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _updateHomeWidget() async {
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
-    final data = _tasks
-        .where((t) {
-          if (t.dueDate == null) return false;
-          final due =
-              DateTime(t.dueDate!.year, t.dueDate!.month, t.dueDate!.day);
-          return !t.isDone && !due.isAfter(today);
-        }) // keep only pending tasks due today or earlier
+    final data = _tasksForTab(0)
+        .where((t) => !t.isDone)
         .map((t) => '• ${t.title}')
         .join('\n');
 


### PR DESCRIPTION
## Summary
- Ensure home widget uses the same task order as the app list by generating widget data from the filtered task list

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aea5ea3e0c832b93e97fbe9b16be06