### PR TITLE
Sort completed tasks to bottom

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -11,6 +11,7 @@ import '../models/task.dart';
 import '../services/log_service.dart';
 import '../services/storage_service.dart';
 import '../utils/date_utils.dart';
+import '../utils/task_utils.dart';
 import 'about_page.dart';
 import 'app_logs_page.dart';
 import 'changelog_page.dart';
@@ -314,8 +315,7 @@ class _HomePageState extends State<HomePage>
       if (pageIndex == 3) return diff >= 3 && diff < 30;
       return diff >= 30;
     }).toList();
-    list.sort((a, b) => (a.listRanking ?? 1 << 31)
-        .compareTo(b.listRanking ?? 1 << 31));
+    sortTasks(list);
     return list;
   }
 
@@ -357,14 +357,7 @@ class _HomePageState extends State<HomePage>
                 key: isAndroid ? ValueKey(task.uid) : null,
                 task: task,
                 onChanged: () {
-                  setState(() {
-                    task.toggleDone();
-                    if (task.isDone) {
-                      _tasks
-                        ..remove(task)
-                        ..add(task);
-                    }
-                  });
+                  setState(task.toggleDone);
                   _saveTasks();
                 },
                 onMove: (dest) => _moveTask(pageIndex, index, dest),

--- a/lib/utils/task_utils.dart
+++ b/lib/utils/task_utils.dart
@@ -1,0 +1,12 @@
+import '../models/task.dart';
+
+/// Sorts tasks so that pending ones come first and completed ones appear last.
+/// Within each group, tasks are ordered by their [listRanking] value.
+void sortTasks(List<Task> list) {
+  list.sort((a, b) {
+    final doneCompare = (a.isDone ? 1 : 0).compareTo(b.isDone ? 1 : 0);
+    if (doneCompare != 0) return doneCompare;
+    return (a.listRanking ?? 1 << 31)
+        .compareTo(b.listRanking ?? 1 << 31);
+  });
+}

--- a/test/done_task_order_test.dart
+++ b/test/done_task_order_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:best_todo_2/models/task.dart';
+import 'package:best_todo_2/utils/task_utils.dart';
+
+void main() {
+  test('completed tasks are sorted to the end', () {
+    final tasks = [
+      Task(title: 'pending1', isDone: false, listRanking: 1),
+      Task(title: 'done1', isDone: true, listRanking: 2),
+      Task(title: 'pending2', isDone: false, listRanking: 3),
+      Task(title: 'done2', isDone: true, listRanking: 4),
+    ];
+
+    sortTasks(tasks);
+
+    expect(tasks.map((t) => t.title).toList(),
+        ['pending1', 'pending2', 'done1', 'done2']);
+  });
+
+  test('new tasks appear before completed tasks', () {
+    final tasks = [
+      Task(title: 'pending1', isDone: false, listRanking: 1),
+      Task(title: 'done1', isDone: true, listRanking: 2),
+    ];
+    final newTask = Task(title: 'new', isDone: false);
+    tasks.add(newTask);
+
+    sortTasks(tasks);
+
+    expect(tasks.map((t) => t.title).toList(), ['pending1', 'new', 'done1']);
+  });
+}


### PR DESCRIPTION
## Summary
- Ensure tasks lists sort by completion status using a shared `sortTasks` helper
- Simplify task toggle logic so completed items automatically move to the bottom
- Add tests verifying completed tasks stay last and new tasks appear above them

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aebf34aa8c832baca6e95597fc1d1c