### PR TITLE
Add visual feedback for swipe actions

### DIFF
--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -288,12 +288,43 @@ class _TaskTileState extends State<TaskTile>
       ),
     );
 
-    
-    content = AnimatedSlide(
+
+    final slide = AnimatedSlide(
       offset: Offset(_dragOffset / MediaQuery.of(context).size.width, 0),
       duration:
           _dragging ? Duration.zero : const Duration(milliseconds: 200),
       child: content,
+    );
+
+    Widget? background;
+    if (_dragOffset != 0) {
+      final dragToDelete =
+          widget.swipeLeftDelete ? _dragOffset < 0 : _dragOffset > 0;
+      if (dragToDelete) {
+        background = Positioned.fill(
+          child: Container(color: Colors.red.withOpacity(0.5)),
+        );
+      } else {
+        final alignment =
+            widget.swipeLeftDelete ? Alignment.centerLeft : Alignment.centerRight;
+        final icon =
+            widget.swipeLeftDelete ? Icons.arrow_forward : Icons.arrow_back;
+        background = Positioned.fill(
+          child: Container(
+            alignment: alignment,
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: Icon(icon,
+                color: Theme.of(context).colorScheme.primary),
+          ),
+        );
+      }
+    }
+
+    content = Stack(
+      children: [
+        if (background != null) background,
+        slide,
+      ],
     );
 
     if (isAndroid) {


### PR DESCRIPTION
## Summary
- highlight delete swipes with a red background
- show directional arrow when swiping to move a task

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aecaafaeb0832b9229de8f6486d3ad