### PR TITLE
Fix task completion when editing description

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -366,7 +366,8 @@ class _HomePageState extends State<HomePage>
               final tile = TaskTile(
                 key: isAndroid ? ValueKey(task.uid) : null,
                 task: task,
-                onChanged: () {
+                onChanged: _saveTasks,
+                onToggle: () {
                   setState(task.toggleDone);
                   _saveTasks();
                 },

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -10,6 +10,7 @@ import '../config.dart';
 class TaskTile extends StatefulWidget {
   final Task task;
   final VoidCallback onChanged;
+  final VoidCallback onToggle;
   final void Function(int destination) onMove;
   final VoidCallback onMoveNext;
   final VoidCallback onDelete;
@@ -21,6 +22,7 @@ class TaskTile extends StatefulWidget {
     Key? key,
     required this.task,
     required this.onChanged,
+    required this.onToggle,
     required this.onMove,
     required this.onMoveNext,
     required this.onDelete,
@@ -153,7 +155,7 @@ class _TaskTileState extends State<TaskTile>
       minLeadingWidth: isAndroid ? 0 : null,
       leading: Checkbox(
         value: widget.task.isDone,
-        onChanged: (_) => setState(() => widget.onChanged()),
+        onChanged: (_) => setState(() => widget.onToggle()),
       ),
       title: Text(
         widget.task.title,

--- a/test/task_tile_description_edit_test.dart
+++ b/test/task_tile_description_edit_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:best_todo_2/models/task.dart';
+import 'package:best_todo_2/ui/task_tile.dart';
+
+void main() {
+  testWidgets('editing description does not toggle task done', (tester) async {
+    final task = Task(title: 'Task');
+    int toggleCount = 0;
+    int saveCount = 0;
+
+    await tester.pumpWidget(MaterialApp(
+      home: TaskTile(
+        task: task,
+        onChanged: () => saveCount++,
+        onToggle: () => toggleCount++,
+        onMove: (_) {},
+        onMoveNext: () {},
+        onDelete: () {},
+        pageIndex: 0,
+      ),
+    ));
+
+    // Expand the tile to reveal the description field.
+    await tester.tap(find.text('Task'));
+    await tester.pumpAndSettle();
+
+    // Enter description text and unfocus the field.
+    await tester.enterText(find.widgetWithText(TextField, 'Description'), 'New description');
+    await tester.tap(find.text('Task'));
+    await tester.pumpAndSettle();
+
+    expect(saveCount, 1);
+    expect(toggleCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- separate task toggle and save callbacks in TaskTile
- prevent description edits from marking tasks complete
- add regression test for description editing

## Testing
- ❌ `flutter test test/task_tile_description_edit_test.dart` (flutter: command not found)
- ❌ `dart test test/task_tile_description_edit_test.dart` (dart: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aeca6643fc832bad8c35a6011e19a2