### PR TITLE
Track app startup times with graph view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.41] - 2025-08-27
+- log startup duration and display graph of last 100 startups
+
 ## [0.1.40] - 2025-08-27
 - update icons to V2
 - added text "no tasks for today" when there are no tasks for today.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,15 +5,20 @@ import 'ui/settings_page.dart';
 import 'ui/app_logs_page.dart';
 import 'ui/intro_page.dart';
 import 'config.dart';
+import 'services/startup_time_service.dart';
 
 const Color _seedColor = Color(0xFF005FDD);
 
 Future<void> main() async {
+  StartupTimeService.start();
   WidgetsFlutterBinding.ensureInitialized();
   await Config.load();
   final prefs = await SharedPreferences.getInstance();
   final showIntro = !(prefs.getBool('intro_shown') ?? false);
   runApp(MyApp(showIntro: showIntro));
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    StartupTimeService.record();
+  });
 }
 
 class MyApp extends StatefulWidget {

--- a/lib/services/startup_time_service.dart
+++ b/lib/services/startup_time_service.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'log_service.dart';
+
+/// Records and persists application startup durations.
+class StartupTimeService {
+  static const _fileName = 'startup_times.json';
+  static final Stopwatch _stopwatch = Stopwatch();
+
+  /// Start measuring the startup time.
+  static void start() {
+    _stopwatch
+      ..reset()
+      ..start();
+  }
+
+  /// Stop the timer, log the result and persist it.
+  static Future<void> record() async {
+    if (_stopwatch.isRunning) {
+      _stopwatch.stop();
+    }
+    final ms = _stopwatch.elapsedMilliseconds;
+    LogService.add('Startup', 'App ready in ${ms}ms');
+    final times = await _loadTimes();
+    times.add(ms);
+    if (times.length > 100) {
+      times.removeRange(0, times.length - 100);
+    }
+    await _saveTimes(times);
+  }
+
+  /// Retrieve the persisted list of startup times in milliseconds.
+  static Future<List<int>> getStartupTimes() => _loadTimes();
+
+  static Future<File> _getFile() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/$_fileName');
+  }
+
+  static Future<List<int>> _loadTimes() async {
+    try {
+      final file = await _getFile();
+      if (!await file.exists()) return <int>[];
+      final data = jsonDecode(await file.readAsString()) as List<dynamic>;
+      return data.cast<int>();
+    } catch (_) {
+      return <int>[];
+    }
+  }
+
+  static Future<void> _saveTimes(List<int> times) async {
+    try {
+      final file = await _getFile();
+      await file.writeAsString(jsonEncode(times), flush: true);
+    } catch (_) {}
+  }
+}
+

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -15,6 +15,7 @@ import '../utils/task_utils.dart';
 import 'about_page.dart';
 import 'app_logs_page.dart';
 import 'changelog_page.dart';
+import 'startup_times_page.dart';
 import 'deleted_items_page.dart';
 import 'settings_page.dart';
 import 'task_tile.dart';
@@ -452,6 +453,16 @@ class _HomePageState extends State<HomePage>
                 Navigator.pop(context);
                 Navigator.of(context).push(
                   MaterialPageRoute(builder: (_) => const AppLogsPage()),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.show_chart),
+              title: const Text('Startup Times'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const StartupTimesPage()),
                 );
               },
             ),

--- a/lib/ui/startup_times_page.dart
+++ b/lib/ui/startup_times_page.dart
@@ -1,0 +1,56 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../services/startup_time_service.dart';
+
+/// Displays a graph of recent application startup durations.
+class StartupTimesPage extends StatefulWidget {
+  const StartupTimesPage({Key? key}) : super(key: key);
+
+  @override
+  State<StartupTimesPage> createState() => _StartupTimesPageState();
+}
+
+class _StartupTimesPageState extends State<StartupTimesPage> {
+  List<int> _times = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final times = await StartupTimeService.getStartupTimes();
+    setState(() => _times = times);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Startup Times')),
+      body: _times.isEmpty
+          ? const Center(child: Text('No startup records yet'))
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: LineChart(
+                LineChartData(
+                  borderData: FlBorderData(show: false),
+                  titlesData: FlTitlesData(show: false),
+                  lineBarsData: [
+                    LineChartBarData(
+                      spots: [
+                        for (var i = 0; i < _times.length; i++)
+                          FlSpot(i.toDouble(), _times[i].toDouble()),
+                      ],
+                      isCurved: false,
+                      dotData: FlDotData(show: true),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   file_selector: ^1.0.0
   url_launcher: ^6.2.5
   uuid: ^3.0.7
+  fl_chart: ^0.63.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- log application startup duration
- persist last 100 startup times
- add Startup Times page with graph and menu entry

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af48b967c8832ba7a6424dbb581c37