### PR TITLE
Schedule widget update at midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - log startup duration and display graph of last 100 startups
 - show startup time graph scaled 0–3s with a red zone above 1s
 - added short text in About page.
+- widget will update at midnight to show tasks for the new day.
 
 ## [0.1.39] - 2025-08-27
 - added animation for sliding actions

--- a/lib/ui/about_page.dart
+++ b/lib/ui/about_page.dart
@@ -25,10 +25,10 @@ class AboutPage extends StatelessWidget {
               const Text(
                 'BestToDo is a lightweight, privacy-focused task manager designed to help you stay productive without the clutter.\n'
                 'It emphasizes:\n\n'
-                'Speed: launches in under a second.\n'
-                'Minimal interactions: built for the fewest clicks possible.\n'
-                'Privacy first: no ads, no tracking, no data collection.\n'
-                'Open source: transparent code you can trust.\n\n'
+                '- Speed: launches in under a second.\n'
+                '- Minimal interactions: built for the fewest clicks possible.\n'
+                '- Privacy first: no ads, no tracking, no data collection.\n'
+                '- Open source: transparent code you can trust.\n\n'
                 'With simple swipes you can reschedule tasks for tomorrow, next week, or later. Notes and labels help keep things organized while keeping the interface clean and intuitive.\n\n'
                 'BestToDo is a product of Mfficiency, created to make everyday productivity tools faster, leaner, and user-controlled.',
                 textAlign: TextAlign.left,

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -46,6 +46,7 @@ class _HomePageState extends State<HomePage>
 
   late final TabController _tabController;
   final TextEditingController _controller = TextEditingController();
+  Timer? _midnightTimer;
 
   /// Day offsets for each tab. The last two entries represent
   /// "next week" and "next month" respectively.
@@ -86,13 +87,26 @@ class _HomePageState extends State<HomePage>
     });
     HomeWidget.setAppGroupId(appGroupId).catchError((_) {});
     _loadTasks();
+    _scheduleMidnightUpdate();
   }
 
   @override
   void dispose() {
     _tabController.dispose();
     _controller.dispose();
+    _midnightTimer?.cancel();
     super.dispose();
+  }
+
+  void _scheduleMidnightUpdate() {
+    _midnightTimer?.cancel();
+    final now = DateTime.now();
+    final tomorrow = DateTime(now.year, now.month, now.day + 1);
+    final duration = tomorrow.difference(now);
+    _midnightTimer = Timer(duration, () {
+      _updateHomeWidget();
+      _scheduleMidnightUpdate();
+    });
   }
 
   void _addTask(String title) {


### PR DESCRIPTION
## Summary
- schedule a timer to refresh the home widget at midnight so the next day's tasks are displayed
- ensure timer is cancelled on dispose and rescheduled nightly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af532ccfa4832badd170e7c23c2c9c