### PR TITLE
Move auto-deleted tasks to Deleted Items list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.42] - 2025-08-27
+- move automatically deleted tasks to Deleted Items list so they can be restored later.
+
 ## [0.1.41] - 2025-08-27
 - changed menu items
 - added padding to startup time graph

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -63,6 +63,7 @@ class _HomePageState extends State<HomePage>
 
   Future<void> _loadTasks() async {
     final loaded = await _storageService.loadTaskList();
+    final deleted = await _storageService.loadDeletedTaskList();
     if (loaded.isEmpty) {
       _tasks.addAll(
         Config.initialTasks.map((t) => Task(title: t, dueDate: _currentDate)),
@@ -70,6 +71,7 @@ class _HomePageState extends State<HomePage>
     } else {
       _tasks.addAll(loaded);
     }
+    _deletedTasks.addAll(deleted);
     LogService.add('HomePage._loadTasks',
         '*** Tasks loaded into widget (${_tasks.length}) ***');
     if (mounted) {
@@ -188,6 +190,7 @@ class _HomePageState extends State<HomePage>
           _deletedTasks.removeLast();
         }
       });
+      _saveTasks();
     });
 
     ScaffoldMessenger.of(context)
@@ -283,6 +286,7 @@ class _HomePageState extends State<HomePage>
       }
     }
     _storageService.saveTaskList(_tasks);
+    _storageService.saveDeletedTaskList(_deletedTasks);
     _updateHomeWidget();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.41+11
+version: 0.1.42+12
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -15,7 +15,8 @@ class _FakePathProvider extends PathProviderPlatform {
 }
 
 void main() {
-  test('loadTaskList removes completed tasks on new day', () async {
+  test('loadTaskList moves completed tasks to deleted file on new day',
+      () async {
     final tempDir = await Directory.systemTemp.createTemp();
     PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
 
@@ -33,6 +34,8 @@ void main() {
     final loaded = await service.loadTaskList();
     expect(loaded.length, 1);
     expect(loaded.first.title, 'pending');
+    final deleted = await service.loadDeletedTaskList();
+    expect(deleted.map((t) => t.title).toList(), ['done']);
   });
 
   test('importTaskList assigns unique ids when missing or duplicated', () async {


### PR DESCRIPTION
## Summary
- persist deleted tasks in storage and track them across sessions
- load deleted tasks into the app and save them when removing tasks
- test that completed tasks removed on a new day are added to the deleted file

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b04b59f3f4832b9314fbb9850c7aa2