### PR TITLE
feat: enlarge list icons

### DIFF
--- a/lib/ui/deleted_items_page.dart
+++ b/lib/ui/deleted_items_page.dart
@@ -22,6 +22,7 @@ class DeletedItemsPage extends StatelessWidget {
           return ListTile(
             leading: IconButton(
               icon: const Icon(Icons.restore),
+              iconSize: 30,
               tooltip: 'Restore',
               onPressed: () => onRestore(task),
             ),

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -365,6 +365,7 @@ class _HomePageState extends State<HomePage>
               ),
               IconButton(
                 icon: const Icon(Icons.add),
+                iconSize: 30,
                 onPressed: () => _addTask(_controller.text),
               )
             ],
@@ -431,7 +432,7 @@ class _HomePageState extends State<HomePage>
               ),
             ),
             ListTile(
-              leading: const Icon(Icons.settings),
+              leading: const Icon(Icons.settings, size: 30),
               title: const Text('Settings'),
               onTap: () {
                 Navigator.pop(context);
@@ -445,7 +446,7 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.delete),
+              leading: const Icon(Icons.delete, size: 30),
               title: const Text('Deleted Items'),
               onTap: () {
                 Navigator.pop(context);
@@ -460,7 +461,7 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.info),
+              leading: const Icon(Icons.info, size: 30),
               title: const Text('About'),
               onTap: () {
                 Navigator.pop(context);
@@ -470,7 +471,7 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.history),
+              leading: const Icon(Icons.history, size: 30),
               title: const Text('Changelog'),
               onTap: () {
                 Navigator.pop(context);
@@ -480,7 +481,7 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.list_alt),
+              leading: const Icon(Icons.list_alt, size: 30),
               title: const Text('App Logs'),
               onTap: () {
                 Navigator.pop(context);
@@ -490,7 +491,7 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.show_chart),
+              leading: const Icon(Icons.show_chart, size: 30),
               title: const Text('Startup Times'),
               onTap: () {
                 Navigator.pop(context);
@@ -500,7 +501,7 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.file_download),
+              leading: const Icon(Icons.file_download, size: 30),
               title: const Text('Export Tasks'),
               onTap: () {
                 Navigator.pop(context);
@@ -508,7 +509,7 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.file_upload),
+              leading: const Icon(Icons.file_upload, size: 30),
               title: const Text('Import Tasks'),
               onTap: () {
                 Navigator.pop(context);
@@ -537,6 +538,7 @@ class _HomePageState extends State<HomePage>
                   children: [
                     IconButton(
                       icon: const Icon(Icons.chevron_left),
+                      iconSize: 30,
                       onPressed: () => _changeDate(-1),
                     ),
                     Text(
@@ -545,6 +547,7 @@ class _HomePageState extends State<HomePage>
                     ),
                     IconButton(
                       icon: const Icon(Icons.chevron_right),
+                      iconSize: 30,
                       onPressed: () => _changeDate(1),
                     ),
                   ],

--- a/lib/ui/task_tile.dart
+++ b/lib/ui/task_tile.dart
@@ -130,6 +130,7 @@ class _TaskTileState extends State<TaskTile>
         if (_expanded)
           IconButton(
             icon: const Icon(Icons.expand_less),
+            iconSize: 30,
             tooltip: 'Collapse',
             onPressed: _toggleExpanded,
           ),
@@ -137,11 +138,13 @@ class _TaskTileState extends State<TaskTile>
           if (widget.showSwipeButton)
             IconButton(
               icon: const Icon(Icons.swipe),
+              iconSize: 30,
               tooltip: 'Reschedule',
               onPressed: _startOptions,
             ),
           IconButton(
             icon: const Icon(Icons.delete),
+            iconSize: 30,
             tooltip: 'Delete',
             onPressed: widget.onDelete,
           ),
@@ -310,7 +313,7 @@ class _TaskTileState extends State<TaskTile>
             color: Colors.red.withOpacity(0.5),
             alignment: alignment,
             padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: const Icon(Icons.delete, color: Colors.white),
+            child: const Icon(Icons.delete, color: Colors.white, size: 30),
           ),
         );
       } else {
@@ -322,8 +325,11 @@ class _TaskTileState extends State<TaskTile>
           child: Container(
             alignment: alignment,
             padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: Icon(icon,
-                color: Theme.of(context).colorScheme.primary),
+            child: Icon(
+              icon,
+              color: Theme.of(context).colorScheme.primary,
+              size: 30,
+            ),
           ),
         );
       }


### PR DESCRIPTION
## Summary
- enlarge drawer menu icons for better visibility
- increase task and deleted item action icon sizes by 25%

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b5788b7094832bb4291dfa36837b4a