### PR TITLE
Ensure consistent primary blue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.1.41] - 2025-08-27
 - changed menu items
 - added padding to startup time graph
+- fixed inconsistent primary color in menu and checkbox
 
 ## [0.1.40] - 2025-08-27
 - update icons to V2

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,14 +67,15 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'BestToDo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: _seedColor),
+        colorScheme: ColorScheme.fromSeed(seedColor: _seedColor)
+            .copyWith(primary: _seedColor),
         useMaterial3: true,
       ),
       darkTheme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: _seedColor,
           brightness: Brightness.dark,
-        ),
+        ).copyWith(primary: _seedColor),
         useMaterial3: true,
       ),
       themeMode: Config.darkMode ? ThemeMode.dark : ThemeMode.light,


### PR DESCRIPTION
## Summary
- Use seed color #005FDD directly as primary color so menus and checkboxes match the intended blue
- Document primary color fix in changelog

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0672de684832bb79c494618f58fb9