### PR TITLE
Bump Flutter to 3.29.2 in the test workflow

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.0'
+          flutter-version: '3.29.2'
           channel: 'stable'
 
       - name: Install dependencies


### PR DESCRIPTION
Bumps the `Flutter Test` workflow from Flutter 3.22.0 → 3.29.2 (matching the project's `.metadata` revision).

3.22.0 can't compile `Color.withValues()` used by the countdown code (`lib/utils/date_time_format.dart`), so `widget_test.dart` failed to load and the suite was red. This aligns the test runner with the version the app actually targets.

https://claude.ai/code/session_01HBxGUg6aA9LgufbP1E6RvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBxGUg6aA9LgufbP1E6RvK)_