### PR TITLE
Chronize: center-on-now Today, momentum scroll, tap-to-create/edit tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.78] - 2026-06-05
+- chronize: the "Today" button now centers the view on the current time instead of pinning it to the top
+- chronize: flinging the timeline keeps gliding and slows to a stop (momentum scrolling) instead of halting on release
+- chronize: tap an empty spot on the timeline to create a task with that exact deadline (date + time); tap a task to edit its title, deadline and done state, or delete it
+- tasks: a deadline time set on the Chronize timeline is preserved and no longer overwritten by the default 18:00 normalization
+
 ## [0.1.77] - 2026-06-05
 - chronize: when no event is in view, two centered cards point to the nearest past (↑) and future (↓) events, showing how far away each is; tap a card to jump there. They hide as soon as an event scrolls into view
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.79] - 2026-06-05
+- chronize: the off-screen event hints are subtler — a small lowercase distance pill (e.g. "3 hours") with the direction arrow moved outside the pill (above for earlier, below for later), so the hint is one line tall and the wording no longer says "earlier"/"in"
+
 ## [0.1.78] - 2026-06-05
 - chronize: the "Today" button now centers the view on the current time instead of pinning it to the top
 - chronize: flinging the timeline keeps gliding and slows to a stop (momentum scrolling) instead of halting on release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.77] - 2026-06-05
+- chronize: when no event is in view, two centered cards point to the nearest past (↑) and future (↓) events, showing how far away each is; tap a card to jump there. They hide as soon as an event scrolls into view
+
 ## [0.1.76] - 2026-06-05
 - chronize: the left timeline now zooms on a continuous axis — time marks fade in and spread apart as you zoom in (2h → 1h → 30m → 10m → 5m) and fade away when zooming out, with the day marks always visible
 - chronize: tasks are placed on the timeline by their time, cascading when they would overlap, and a live "now" line tracks the clock

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 flutter pub get
 flutter run -d chrome
-flutter build apk --release 
+flutter build apk --release
 #after installing the android SDK
 ```
 

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -18,6 +18,10 @@ class Task {
   DateTime? deletedAt;
   bool autoDeleted;
   bool isDone;
+  /// When true, [dueDate]'s time-of-day was set deliberately (e.g. placed on the
+  /// Chronize timeline) and must not be overwritten by the default 18:00
+  /// deadline normalization.
+  bool hasExplicitTime;
   int? listRanking;
   bool isRecurring;
   DateTime? recurrenceEndDate;
@@ -39,6 +43,7 @@ class Task {
     this.deletedAt,
     this.autoDeleted = false,
     this.isDone = false,
+    this.hasExplicitTime = false,
     this.listRanking,
     this.isRecurring = false,
     this.recurrenceEndDate,
@@ -78,6 +83,7 @@ class Task {
           : null,
       autoDeleted: json['autoDeleted'] as bool? ?? false,
       isDone: json['isDone'] as bool? ?? false,
+      hasExplicitTime: json['hasExplicitTime'] as bool? ?? false,
       listRanking: json['listRanking'] as int?,
       isRecurring: json['isRecurring'] as bool? ?? false,
       recurrenceEndDate: json['recurrenceEndDate'] != null
@@ -103,6 +109,7 @@ class Task {
         'deletedAt': deletedAt?.toIso8601String(),
         'autoDeleted': autoDeleted,
         'isDone': isDone,
+        'hasExplicitTime': hasExplicitTime,
         if (listRanking != null) 'listRanking': listRanking,
         'isRecurring': isRecurring,
         'recurrenceEndDate': recurrenceEndDate?.toIso8601String(),

--- a/lib/ui/chronize_page.dart
+++ b/lib/ui/chronize_page.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
 
 import '../config.dart';
 import '../models/task.dart';
 import 'subpage_app_bar.dart';
-import 'task_detail_page.dart';
 
 /// A level's marks start fading in once they are at least [kMarkFadeStartPx]
 /// apart on screen and are fully opaque by [kMarkFadeFullPx]. Because finer
@@ -68,7 +68,22 @@ class _MarkLevel {
 class ChronizePage extends StatefulWidget {
   final List<Task> tasks;
 
-  const ChronizePage({Key? key, required this.tasks}) : super(key: key);
+  /// Create a task at the given deadline (date + time), tapped on the timeline.
+  final void Function(String title, DateTime dueDate)? onCreateTask;
+
+  /// Called after a task is edited in place so the host can persist the change.
+  final VoidCallback? onTaskChanged;
+
+  /// Delete a task chosen on the timeline.
+  final void Function(Task task)? onDeleteTask;
+
+  const ChronizePage({
+    Key? key,
+    required this.tasks,
+    this.onCreateTask,
+    this.onTaskChanged,
+    this.onDeleteTask,
+  }) : super(key: key);
 
   @override
   State<ChronizePage> createState() => _ChronizePageState();
@@ -78,7 +93,7 @@ class ChronizePage extends StatefulWidget {
 enum _Wheel { hour, day, month }
 
 class _ChronizePageState extends State<ChronizePage>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   /// Mark levels, coarsest to finest. The day level is always visible so the
   /// ruler never goes blank when fully zoomed out.
   static const List<_MarkLevel> _levels = [
@@ -152,10 +167,18 @@ class _ChronizePageState extends State<ChronizePage>
   double _glideStartPpm = 0;
   double _glideTargetPpm = 0;
 
+  // Momentum (fling) after a pan: an unbounded controller driven by a friction
+  // simulation so the timeline keeps gliding and slows to a stop on release.
+  late final AnimationController _fling;
+  double _flingPpm = 1;
+
   // Pinch / drag anchors captured at the start of a scale gesture.
   double _gestureStartPpm = 0.9;
   double _gestureStartTop = 0;
   double _gestureStartFocalY = 0;
+
+  // Last measured viewport height, used to center the focus (e.g. "Today").
+  double _viewportHeight = 0;
 
   // Debounce so spinning a wheel stays smooth: the glide runs once, after the
   // wheel settles.
@@ -183,12 +206,16 @@ class _ChronizePageState extends State<ChronizePage>
       ..addStatusListener((status) {
         if (status == AnimationStatus.completed) _syncWheelsToFocus();
       });
+
+    _fling = AnimationController.unbounded(vsync: this)
+      ..addListener(_onFlingTick);
   }
 
   @override
   void dispose() {
     _settleTimer?.cancel();
     _glide.dispose();
+    _fling.dispose();
     _hourWheel.dispose();
     _dayWheel.dispose();
     _monthWheel.dispose();
@@ -255,6 +282,7 @@ class _ChronizePageState extends State<ChronizePage>
       v.clamp(_minPixelsPerMinute, _maxPixelsPerMinute);
 
   void _animateTo({double? topMinute, double? pixelsPerMinute}) {
+    _fling.stop();
     _glideStartTop = _topMinute;
     _glideTargetTop = topMinute ?? _topMinute;
     _glideStartPpm = _pixelsPerMinute;
@@ -277,10 +305,18 @@ class _ChronizePageState extends State<ChronizePage>
     });
   }
 
+  // Friction-driven momentum: drive _topMinute from the unbounded controller
+  // (position is in pixel space, so the deceleration feel is zoom-independent).
+  void _onFlingTick() {
+    setState(() => _topMinute = _fling.value / _flingPpm);
+    _syncWheelsToFocus();
+  }
+
   // ---- Direct manipulation (pinch zoom + single-finger pan) ----
 
   void _onScaleStart(ScaleStartDetails details) {
     _glide.stop();
+    _fling.stop();
     _gestureStartPpm = _pixelsPerMinute;
     _gestureStartTop = _topMinute;
     _gestureStartFocalY = details.localFocalPoint.dy;
@@ -301,10 +337,27 @@ class _ChronizePageState extends State<ChronizePage>
     _syncWheelsToFocus();
   }
 
+  /// On release, keep gliding with friction so the timeline slows to a stop
+  /// instead of halting instantly.
+  void _onScaleEnd(ScaleEndDetails details) {
+    final velocity = details.velocity.pixelsPerSecond.dy;
+    if (velocity.abs() < 50) return; // ignore tiny residual motion
+    _flingPpm = _pixelsPerMinute;
+    // Work in pixel space: position = topMinute * ppm, which moves opposite to
+    // the finger's vertical velocity.
+    final simulation = FrictionSimulation(
+      0.135,
+      _topMinute * _flingPpm,
+      -velocity,
+    );
+    _fling.animateWith(simulation);
+  }
+
   /// Desktop / web: the mouse wheel or trackpad scrolls the timeline.
   void _onPointerSignal(PointerSignalEvent event) {
     if (event is! PointerScrollEvent) return;
     _glide.stop();
+    _fling.stop();
     setState(() {
       _topMinute += event.scrollDelta.dy / _pixelsPerMinute;
     });
@@ -325,9 +378,13 @@ class _ChronizePageState extends State<ChronizePage>
   }
 
   void _returnToToday() {
-    final now = DateTime.now();
-    final focus = DateTime(now.year, now.month, now.day, now.hour);
-    _animateTo(topMinute: _minutesFromBase(focus).toDouble());
+    final nowMinute = _minutesFromBase(DateTime.now()).toDouble();
+    // Center the current time in the viewport (rather than pinning it to the
+    // top edge) so "Today" lands on the actual current hour.
+    final target = _viewportHeight > 0
+        ? nowMinute - _viewportHeight / (2 * _pixelsPerMinute)
+        : nowMinute;
+    _animateTo(topMinute: target);
   }
 
   // ---- Wheel <-> timeline sync ----
@@ -515,12 +572,15 @@ class _ChronizePageState extends State<ChronizePage>
     return LayoutBuilder(
       builder: (context, constraints) {
         final height = constraints.maxHeight;
+        _viewportHeight = height;
         final eventNav = _buildEventNav(theme, height);
         return Listener(
           onPointerSignal: _onPointerSignal,
           child: GestureDetector(
             onScaleStart: _onScaleStart,
             onScaleUpdate: (details) => _onScaleUpdate(details),
+            onScaleEnd: _onScaleEnd,
+            onTapUp: _onBackgroundTapUp,
             child: ClipRect(
               child: Stack(
                 children: [
@@ -720,6 +780,47 @@ class _ChronizePageState extends State<ChronizePage>
     return 'now';
   }
 
+  /// Tapping empty timeline space opens the create-task dialog with the
+  /// deadline set to the tapped position (rounded to 5 minutes).
+  void _onBackgroundTapUp(TapUpDetails details) {
+    if (widget.onCreateTask == null) return;
+    final minute = _topMinute + details.localPosition.dy / _pixelsPerMinute;
+    final rounded = (minute / 5).round() * 5;
+    _openTaskEditor(initialDue: _momentForMinutes(rounded));
+  }
+
+  /// Shows the shared create/edit dialog. With [task] it edits in place; with
+  /// [initialDue] it creates a new task at that deadline.
+  Future<void> _openTaskEditor({Task? task, DateTime? initialDue}) async {
+    final result = await showDialog<_TaskDialogResult>(
+      context: context,
+      builder: (_) => _TaskEditDialog(
+        isEdit: task != null,
+        initialTitle: task?.title ?? '',
+        initialDue: task?.dueDate ?? initialDue ?? DateTime.now(),
+        initialDone: task?.isDone ?? false,
+      ),
+    );
+    if (result == null || !mounted) return;
+
+    if (task == null) {
+      if (result.action == _TaskDialogAction.save &&
+          result.title.trim().isNotEmpty) {
+        widget.onCreateTask?.call(result.title.trim(), result.due);
+      }
+    } else if (result.action == _TaskDialogAction.delete) {
+      widget.onDeleteTask?.call(task);
+    } else {
+      final title = result.title.trim();
+      if (title.isNotEmpty) task.title = title;
+      task.dueDate = result.due;
+      task.hasExplicitTime = true;
+      task.isDone = result.isDone;
+      widget.onTaskChanged?.call();
+    }
+    if (mounted) setState(() {});
+  }
+
   Widget _buildTaskChip(ThemeData theme, Task task) {
     return Material(
       color: task.isDone
@@ -728,13 +829,7 @@ class _ChronizePageState extends State<ChronizePage>
       borderRadius: BorderRadius.circular(6),
       child: InkWell(
         borderRadius: BorderRadius.circular(6),
-        onTap: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => TaskDetailPage(task: task),
-            ),
-          );
-        },
+        onTap: () => _openTaskEditor(task: task),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
           child: Align(
@@ -972,4 +1067,170 @@ class _TimeAxisPainter extends CustomPainter {
       old.surface != surface ||
       old.primary != primary ||
       old.nowColor != nowColor;
+}
+
+/// What the user chose in the create/edit task dialog.
+enum _TaskDialogAction { save, delete }
+
+class _TaskDialogResult {
+  const _TaskDialogResult(
+    this.action, {
+    this.title = '',
+    required this.due,
+    this.isDone = false,
+  });
+
+  final _TaskDialogAction action;
+  final String title;
+  final DateTime due;
+  final bool isDone;
+}
+
+/// Shared dialog to create a task (with a preset deadline) or edit an existing
+/// one. Lets the user set the title, the deadline date and time, and (when
+/// editing) the done state, plus delete.
+class _TaskEditDialog extends StatefulWidget {
+  const _TaskEditDialog({
+    required this.isEdit,
+    required this.initialTitle,
+    required this.initialDue,
+    required this.initialDone,
+  });
+
+  final bool isEdit;
+  final String initialTitle;
+  final DateTime initialDue;
+  final bool initialDone;
+
+  @override
+  State<_TaskEditDialog> createState() => _TaskEditDialogState();
+}
+
+class _TaskEditDialogState extends State<_TaskEditDialog> {
+  late final TextEditingController _titleController;
+  late DateTime _due;
+  late bool _done;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController(text: widget.initialTitle);
+    _due = widget.initialDue;
+    _done = widget.initialDone;
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _due,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) {
+      setState(() => _due =
+          DateTime(picked.year, picked.month, picked.day, _due.hour, _due.minute));
+    }
+  }
+
+  Future<void> _pickTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_due),
+    );
+    if (picked != null) {
+      setState(() => _due = DateTime(
+          _due.year, _due.month, _due.day, picked.hour, picked.minute));
+    }
+  }
+
+  String get _dateLabel {
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${_due.year}-${two(_due.month)}-${two(_due.day)}';
+  }
+
+  String get _timeLabel {
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${two(_due.hour)}:${two(_due.minute)}';
+  }
+
+  void _save() {
+    Navigator.of(context).pop(
+      _TaskDialogResult(
+        _TaskDialogAction.save,
+        title: _titleController.text,
+        due: _due,
+        isDone: _done,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(widget.isEdit ? 'Edit task' : 'New task'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextField(
+            controller: _titleController,
+            autofocus: !widget.isEdit,
+            textInputAction: TextInputAction.done,
+            decoration: const InputDecoration(labelText: 'Title'),
+            onSubmitted: (_) => _save(),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: _pickDate,
+                  icon: const Icon(Icons.event, size: 18),
+                  label: Text(_dateLabel),
+                ),
+              ),
+              const SizedBox(width: 8),
+              OutlinedButton.icon(
+                onPressed: _pickTime,
+                icon: const Icon(Icons.schedule, size: 18),
+                label: Text(_timeLabel),
+              ),
+            ],
+          ),
+          if (widget.isEdit)
+            CheckboxListTile(
+              value: _done,
+              onChanged: (v) => setState(() => _done = v ?? false),
+              title: const Text('Done'),
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+            ),
+        ],
+      ),
+      actions: [
+        if (widget.isEdit)
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(
+              _TaskDialogResult(_TaskDialogAction.delete, due: _due),
+            ),
+            child: Text(
+              'Delete',
+              style: TextStyle(color: theme.colorScheme.error),
+            ),
+          ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _save, child: const Text('Save')),
+      ],
+    );
+  }
 }

--- a/lib/ui/chronize_page.dart
+++ b/lib/ui/chronize_page.dart
@@ -515,6 +515,7 @@ class _ChronizePageState extends State<ChronizePage>
     return LayoutBuilder(
       builder: (context, constraints) {
         final height = constraints.maxHeight;
+        final eventNav = _buildEventNav(theme, height);
         return Listener(
           onPointerSignal: _onPointerSignal,
           child: GestureDetector(
@@ -540,6 +541,7 @@ class _ChronizePageState extends State<ChronizePage>
                     ),
                   ),
                   ..._buildTaskChips(theme, height),
+                  if (eventNav != null) eventNav,
                 ],
               ),
             ),
@@ -586,6 +588,136 @@ class _ChronizePageState extends State<ChronizePage>
       );
     }
     return chips;
+  }
+
+  /// Tasks that sit on the timeline: have a due date and aren't the far-future
+  /// "someday" bucket (year >= 2300).
+  Iterable<Task> get _datedTasks => widget.tasks.where((t) {
+        final d = t.dueDate;
+        return d != null && d.year < 2300;
+      });
+
+  /// When no event is within the viewport, builds the two centered navigator
+  /// cards pointing at the nearest past and future events. Returns null when an
+  /// event is in view (so the cards hide) or there are no dated events at all.
+  Widget? _buildEventNav(ThemeData theme, double height) {
+    if (height <= 0 || _pixelsPerMinute <= 0) return null;
+    final topMin = _topMinute;
+    final bottomMin = _topMinute + height / _pixelsPerMinute;
+    final centerMin = (topMin + bottomMin) / 2;
+
+    double? prev; // nearest event above the viewport (in the past)
+    double? next; // nearest event below the viewport (in the future)
+    for (final task in _datedTasks) {
+      final m = _minutesFromBase(task.dueDate!).toDouble();
+      if (m >= topMin && m <= bottomMin) {
+        return null; // an event is visible -> hide the cards
+      } else if (m < topMin) {
+        if (prev == null || m > prev) prev = m;
+      } else {
+        if (next == null || m < next) next = m;
+      }
+    }
+
+    final prevMin = prev;
+    final nextMin = next;
+    if (prevMin == null && nextMin == null) return null;
+
+    final cards = <Widget>[];
+    if (prevMin != null) {
+      cards.add(_eventNavCard(
+        theme,
+        icon: Icons.keyboard_arrow_up,
+        title: 'Previous event',
+        subtitle: '${_formatGap(centerMin - prevMin)} earlier',
+        targetMinute: prevMin,
+        height: height,
+      ));
+    }
+    if (nextMin != null) {
+      if (cards.isNotEmpty) cards.add(const SizedBox(height: 16));
+      cards.add(_eventNavCard(
+        theme,
+        icon: Icons.keyboard_arrow_down,
+        title: 'Next event',
+        subtitle: 'in ${_formatGap(nextMin - centerMin)}',
+        targetMinute: nextMin,
+        height: height,
+      ));
+    }
+
+    return Positioned(
+      left: _TimeAxisPainter.gutterWidth,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: cards,
+        ),
+      ),
+    );
+  }
+
+  /// One navigator card. Tapping it glides the timeline so [targetMinute] is
+  /// centered in the viewport.
+  Widget _eventNavCard(
+    ThemeData theme, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required double targetMinute,
+    required double height,
+  }) {
+    final scheme = theme.colorScheme;
+    return Material(
+      color: scheme.secondaryContainer,
+      borderRadius: BorderRadius.circular(12),
+      elevation: 2,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => _animateTo(
+          topMinute: targetMinute - height / (2 * _pixelsPerMinute),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 32, color: scheme.onSecondaryContainer),
+              Text(
+                title,
+                style: theme.textTheme.labelLarge
+                    ?.copyWith(color: scheme.onSecondaryContainer),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                subtitle,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSecondaryContainer.withOpacity(0.8),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Formats a positive minute gap as a coarse "3 days" / "5 hours" / "20 min".
+  static String _formatGap(double minutes) {
+    final m = minutes.abs().round();
+    if (m >= 1440) {
+      final days = (m / 1440).round();
+      return days == 1 ? '1 day' : '$days days';
+    }
+    if (m >= 60) {
+      final hours = (m / 60).round();
+      return hours == 1 ? '1 hour' : '$hours hours';
+    }
+    if (m >= 1) return m == 1 ? '1 min' : '$m min';
+    return 'now';
   }
 
   Widget _buildTaskChip(ThemeData theme, Task task) {

--- a/lib/ui/chronize_page.dart
+++ b/lib/ui/chronize_page.dart
@@ -687,20 +687,18 @@ class _ChronizePageState extends State<ChronizePage>
     if (prevMin != null) {
       cards.add(_eventNavCard(
         theme,
-        icon: Icons.keyboard_arrow_up,
-        title: 'Previous event',
-        subtitle: '${_formatGap(centerMin - prevMin)} earlier',
+        up: true,
+        label: _formatGap(centerMin - prevMin),
         targetMinute: prevMin,
         height: height,
       ));
     }
     if (nextMin != null) {
-      if (cards.isNotEmpty) cards.add(const SizedBox(height: 16));
+      if (cards.isNotEmpty) cards.add(const SizedBox(height: 20));
       cards.add(_eventNavCard(
         theme,
-        icon: Icons.keyboard_arrow_down,
-        title: 'Next event',
-        subtitle: 'in ${_formatGap(nextMin - centerMin)}',
+        up: false,
+        label: _formatGap(nextMin - centerMin),
         targetMinute: nextMin,
         height: height,
       ));
@@ -720,48 +718,46 @@ class _ChronizePageState extends State<ChronizePage>
     );
   }
 
-  /// One navigator card. Tapping it glides the timeline so [targetMinute] is
-  /// centered in the viewport.
+  /// One subtle navigator hint: a small pill showing just the distance (e.g.
+  /// "3 hours") with the direction arrow sitting *outside* the pill — above for
+  /// an earlier event, below for a later one — so the pill stays one line tall
+  /// and the arrow + position imply the direction. Tapping the pill glides the
+  /// timeline so [targetMinute] is centered.
   Widget _eventNavCard(
     ThemeData theme, {
-    required IconData icon,
-    required String title,
-    required String subtitle,
+    required bool up,
+    required String label,
     required double targetMinute,
     required double height,
   }) {
     final scheme = theme.colorScheme;
-    return Material(
-      color: scheme.secondaryContainer,
-      borderRadius: BorderRadius.circular(12),
-      elevation: 2,
+    final arrow = Icon(
+      up ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+      size: 20,
+      color: scheme.onSurfaceVariant.withOpacity(0.7),
+    );
+    final pill = Material(
+      color: scheme.surfaceVariant.withOpacity(0.85),
+      borderRadius: BorderRadius.circular(10),
       child: InkWell(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(10),
         onTap: () => _animateTo(
           topMinute: targetMinute - height / (2 * _pixelsPerMinute),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, size: 32, color: scheme.onSecondaryContainer),
-              Text(
-                title,
-                style: theme.textTheme.labelLarge
-                    ?.copyWith(color: scheme.onSecondaryContainer),
-              ),
-              const SizedBox(height: 2),
-              Text(
-                subtitle,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: scheme.onSecondaryContainer.withOpacity(0.8),
-                ),
-              ),
-            ],
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          child: Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: scheme.onSurfaceVariant,
+            ),
           ),
         ),
       ),
+    );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: up ? [arrow, pill] : [pill, arrow],
     );
   }
 

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -766,6 +766,47 @@ class _HomePageState extends State<HomePage>
     LogService.add('HomePage._addTask', 'Added task: $title');
   }
 
+  /// Creates a task from the Chronize timeline at an explicit deadline
+  /// (date + time), preserving the chosen time of day.
+  void _addTaskFromChronize(String title, DateTime dueDate) {
+    if (title.trim().isEmpty) return;
+    final task = Task(
+      title: title.trim(),
+      createdAt: DateTime.now(),
+      dueDate: dueDate,
+      hasExplicitTime: true,
+      listRanking: 1 << 30,
+    );
+    setState(() {
+      _tasks.add(task);
+    });
+    _trackTaskCreated(task);
+    _saveTasks();
+    LogService.add('HomePage._addTaskFromChronize',
+        'Added "$title" due ${dueDate.toIso8601String()}');
+  }
+
+  /// Persists in-place edits made to a task from the Chronize timeline.
+  void _onChronizeTaskChanged() {
+    setState(() {});
+    _saveTasks();
+  }
+
+  /// Deletes a task chosen on the Chronize timeline, moving it to the deleted
+  /// list (consistent with the rest of the app).
+  void _deleteTaskFromChronize(Task task) {
+    final index = _tasks.indexOf(task);
+    if (index < 0) return;
+    setState(() {
+      _tasks.removeAt(index);
+      _tasks.removeWhere((t) => t.recurrenceParentUid == task.uid);
+    });
+    _addToDeletedTasks(task);
+    _saveTasks();
+    _saveDeletedTasks();
+    LogService.add('HomePage._deleteTaskFromChronize', 'Deleted "${task.title}"');
+  }
+
   void _moveTaskToNextPage(int pageIndex, int index) {
     final tasks = _tasksForTab(pageIndex);
     int destination = pageIndex + 1;
@@ -1652,7 +1693,12 @@ class _HomePageState extends State<HomePage>
                     Navigator.pop(context);
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (_) => ChronizePage(tasks: _tasks),
+                        builder: (_) => ChronizePage(
+                        tasks: _tasks,
+                        onCreateTask: _addTaskFromChronize,
+                        onTaskChanged: _onChronizeTaskChanged,
+                        onDeleteTask: _deleteTaskFromChronize,
+                      ),
                       ),
                     );
                   },

--- a/lib/utils/task_utils.dart
+++ b/lib/utils/task_utils.dart
@@ -39,11 +39,17 @@ void applyDefaultDeadlineTimes(List<Task> tasks) {
       if (ra != rb) return ra.compareTo(rb);
       return a.uid.compareTo(b.uid);
     });
-    for (var i = 0; i < dayTasks.length; i++) {
-      final task = dayTasks[i];
+    // Tasks with an explicitly chosen time (e.g. placed on the Chronize
+    // timeline) keep their time; only the remaining tasks get the 18:00, 18:01…
+    // default slots, assigned in listRanking order.
+    var slot = 0;
+    for (final task in dayTasks) {
+      if (task.hasExplicitTime) continue;
       final due = task.dueDate!;
       // Cap at 23:59 so the time never spills into the next calendar day.
-      final minutes = (defaultDeadlineMinutesOfDay + i).clamp(0, 24 * 60 - 1);
+      final minutes =
+          (defaultDeadlineMinutesOfDay + slot).clamp(0, 24 * 60 - 1);
+      slot++;
       final hour = minutes ~/ 60;
       final minute = minutes % 60;
       final updated = DateTime(due.year, due.month, due.day, hour, minute);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.76+46
+version: 0.1.77+47
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.78+48
+version: 0.1.79+49
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.77+47
+version: 0.1.78+48
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/chronize_smoothness_test.dart
+++ b/test/chronize_smoothness_test.dart
@@ -111,5 +111,44 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('shows prev/next navigator cards when no event is in view',
+        (tester) async {
+      final now = DateTime.now();
+      final tasks = [
+        Task(
+          title: 'past',
+          dueDate: now.subtract(const Duration(days: 30)),
+          listRanking: 1,
+        ),
+        Task(
+          title: 'future',
+          dueDate: now.add(const Duration(days: 30)),
+          listRanking: 2,
+        ),
+      ];
+      await tester.pumpWidget(MaterialApp(home: ChronizePage(tasks: tasks)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Previous event'), findsOneWidget);
+      expect(find.text('Next event'), findsOneWidget);
+    });
+
+    testWidgets('hides navigator cards when an event is in view',
+        (tester) async {
+      final now = DateTime.now();
+      final tasks = [
+        Task(
+          title: 'now',
+          dueDate: DateTime(now.year, now.month, now.day, now.hour),
+          listRanking: 1,
+        ),
+      ];
+      await tester.pumpWidget(MaterialApp(home: ChronizePage(tasks: tasks)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Previous event'), findsNothing);
+      expect(find.text('Next event'), findsNothing);
+    });
   });
 }

--- a/test/chronize_smoothness_test.dart
+++ b/test/chronize_smoothness_test.dart
@@ -130,8 +130,11 @@ void main() {
       await tester.pumpWidget(MaterialApp(home: ChronizePage(tasks: tasks)));
       await tester.pumpAndSettle();
 
-      expect(find.text('Previous event'), findsOneWidget);
-      expect(find.text('Next event'), findsOneWidget);
+      // A subtle up/down arrow points at the nearest past/future event, with a
+      // small distance pill ("30 days") and no "earlier/in" wording.
+      expect(find.byIcon(Icons.keyboard_arrow_up), findsOneWidget);
+      expect(find.byIcon(Icons.keyboard_arrow_down), findsOneWidget);
+      expect(find.textContaining('days'), findsWidgets);
     });
 
     testWidgets('hides navigator cards when an event is in view',
@@ -147,8 +150,8 @@ void main() {
       await tester.pumpWidget(MaterialApp(home: ChronizePage(tasks: tasks)));
       await tester.pumpAndSettle();
 
-      expect(find.text('Previous event'), findsNothing);
-      expect(find.text('Next event'), findsNothing);
+      expect(find.byIcon(Icons.keyboard_arrow_up), findsNothing);
+      expect(find.byIcon(Icons.keyboard_arrow_down), findsNothing);
     });
 
     testWidgets('tapping empty timeline opens the new-task dialog',

--- a/test/chronize_smoothness_test.dart
+++ b/test/chronize_smoothness_test.dart
@@ -150,5 +150,39 @@ void main() {
       expect(find.text('Previous event'), findsNothing);
       expect(find.text('Next event'), findsNothing);
     });
+
+    testWidgets('tapping empty timeline opens the new-task dialog',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: ChronizePage(tasks: const [], onCreateTask: (_, __) {}),
+      ));
+      await tester.pumpAndSettle();
+
+      // Tap in the calendar body (left of the wheels, below the header).
+      await tester.tapAt(const Offset(120, 320));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New task'), findsOneWidget);
+    });
+
+    testWidgets('tapping a task opens the edit dialog', (tester) async {
+      final now = DateTime.now();
+      final tasks = [
+        Task(
+          title: 'meeting',
+          dueDate: DateTime(now.year, now.month, now.day, now.hour),
+          listRanking: 1,
+        ),
+      ];
+      await tester.pumpWidget(MaterialApp(
+        home: ChronizePage(tasks: tasks, onTaskChanged: () {}),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('meeting'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit task'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
Builds on the Chronize timeline (continuous zoom + navigator cards) with four changes:

- **Today centers on now** — the "Today" button centers the viewport on the current time instead of pinning it to the top edge.
- **Momentum scrolling** — panning the timeline keeps gliding with friction and slows to a stop on release (was halting instantly).
- **Tap to create / edit** — tapping an empty spot opens a dialog to create a task at that exact deadline (date + time, rounded to 5 min); tapping a task opens the same dialog to edit its title, deadline and done state, or delete it. Wired via `onCreateTask` / `onTaskChanged` / `onDeleteTask`.
- **Honor picked times** — `Task` gains a `hasExplicitTime` flag and `applyDefaultDeadlineTimes` skips those tasks, so a time set on the timeline is preserved instead of being overwritten by the default 18:00 normalization (other tasks keep the 18:00 behavior).

Includes the navigator-cards commit from the previous round and new widget tests for the create/edit dialogs. Opened for CI validation — do not merge yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_0163APMwLnw3djFN1oDx7n7x)_