### PR TITLE
Productivity Stats in Tools, default start page setting, per-alarm volume + DND override + melody preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.91] - 2026-07-07
+- Stats renamed to Productivity Stats and moved into the Tools section of the menu
+- Settings: choose the default start page — the task list or any tool (Alarms, Countdown, Projects, Chronize, Usage Data, Productivity Stats); the chosen tool opens on launch, back returns to the task list
+- alarms: per-alarm volume is now real — every alarm rings its melody at its own volume as a fraction of the device maximum, independent of the phone's current media/ringer/alarm volume (the alarm stream is pinned to max during the ring and restored afterwards)
+- alarms: new "Override Do Not Disturb" switch per alarm — when on, the alarm always plays at its configured volume, even while the phone is silenced or in Do Not Disturb
+- alarms: Preview button next to the melody picker — plays the selected melody at the configured alarm volume (live-updates while changing melody or volume) so sound and loudness can be checked before saving
+- alarms: while the full-screen ring page plays the alarm's own melody, the notification moves to a silent channel (actions and vibration stay) so the default alarm sound no longer plays on top; if melody playback cannot start, the notification sound keeps ringing as before
+
 ## [0.1.90] - 2026-07-07
 - Editable project name/description + persistence (ProjectService)
 - Move Projects drawer entry into Tools section

--- a/SPEC.md
+++ b/SPEC.md
@@ -202,8 +202,8 @@ on change/focus loss.
 (`ScheduleView`); tabs become scroll anchors; overdue rolls up under Today; each day
 section is a `ReorderableListView`; "Someday" holds the 2300-sentinel tasks.
 
-**Drawer:** Settings, Deleted Items, Your Stats, About, Changelog, App Logs, Startup Times,
-Tools ▸ (Alarms, Countdown, Chronize, Usage Data).
+**Drawer:** Settings, Deleted Items, About, Changelog, App Logs, Startup Times,
+Tools ▸ (Alarms, Countdown, Projects, Chronize, Productivity Stats, Usage Data).
 
 **Home widget updates** after every save and at a self-rescheduling midnight timer: writes
 the "due today or overdue" list text (or "Well done! No more tasks for today!"), a progress
@@ -216,7 +216,10 @@ tasks, 20 deleted tasks, and 14 days of stats (marker strings prevent re-seeding
 
 Appearance: dark mode, icon tabs, 24-hour time (default on), date format (6 choices,
 default `dd.MM.yy`). Tasks: add-to-top, swipe-left-delete, default delay 0–10 s slider,
-start tab, start in schedule view, Chronize hour wheel. Widget: progress line. Notifications:
+start tab, default start page (`startTool`: the task list or any tool — Alarms, Countdown,
+Projects, Chronize, Usage Data, Productivity Stats; the tool is pushed on top of the task
+list after loading, so back lands on the tasks), start in schedule view, Chronize hour
+wheel. Widget: progress line. Notifications:
 enable (default **off**), quiet hours (default 22:00–07:00, stored as minutes-since-midnight;
 applied to task notifications only, never alarms), default notification delay (dev 3 s /
 prod 300 s). SMS report: see §7. Export/Import buttons. `Config.applyMap` is defensive
@@ -233,10 +236,16 @@ hardware — see Part II §"The reliability arc" and `.claude/notes/alarm-work-s
 ### 5.1 Model & ids
 
 `Alarm`: uid, name, description, hour/minute, optional one-off `date`, `isRepeating` +
-`repeatDays` (Mon=1..Sun=7), `vibrate`, `color`, snooze (enabled, duration min, default 9),
-`enabled`. (`volume`, `melody`, `snoozeMaxCount` are stored but **not implemented** — known
-deferred work.) `nextOccurrence()` is the scheduling brain; a one-off *without* a date
-re-arms for tomorrow after firing (no delivered-callback exists to auto-disable it).
+`repeatDays` (Mon=1..Sun=7), `vibrate`, `overrideDnd` (default off), `color`, snooze
+(enabled, duration min, default 9), `enabled`, `melody` + `volume` (0–1, fraction of the
+device maximum). Melody/volume are played by the ring UI through the native
+`besttodo/alarm_audio` channel (`AlarmSoundPlayer.kt`): synthesized melodies on the ALARM
+stream, stream pinned to max during playback (previous level restored on stop) with the
+alarm's volume applied as track gain — so loudness is independent of the phone's current
+volume; `overrideDnd` additionally plays through Do Not Disturb. (`snoozeMaxCount` is
+stored but **not implemented** — known deferred work.) `nextOccurrence()` is the
+scheduling brain; a one-off *without* a date re-arms for tomorrow after firing (no
+delivered-callback exists to auto-disable it).
 
 Deterministic id scheme so every path can find an alarm's notifications:
 `base = (uid.hashCode & 0x1FFFFFF) * 8`; `base+0` one-off/snooze slot, `base+1..7` weekday
@@ -277,7 +286,10 @@ Android channel settings are immutable), Importance.max, `audioAttributesUsage: 
 (alarm volume stream), `fullScreenIntent`, `ongoing`, insistent flag (`additionalFlags:
 [4]`) so it loops until acted on. Actions: Snooze (if enabled) + Dismiss. Snooze schedules
 `now + snoozeMinutes` into the `base+0` slot through the same ladder and gets its own
-watchdog cover.
+watchdog cover. When the ring UI starts the alarm's own melody it hands the notification
+over to the sound-less channel `alarm_notifications_silent_v1` (same actions/vibration, no
+channel sound) so the default sound and the melody don't stack; if melody playback can't
+start, the loud channel keeps ringing as the reliability baseline.
 
 **Full-screen ring UI (0.1.88):** a ringing alarm presents `AlarmRingPage`
 (`lib/ui/alarm_ring_page.dart`) — a clock-app-style full-screen page (live clock, alarm
@@ -443,7 +455,7 @@ decimals in every unit (years=days/365.25, months=days/30.4375, …). Past timer
 (orange). Notify-on-zero fires a notification once (suppressed for already-past timers so
 they never retro-fire; suppression is per-session).
 
-### 10.3 Your Stats
+### 10.3 Productivity Stats (formerly "Your Stats"; lives under Tools since 0.1.91)
 Three sections: (a) GitHub-style 52-week × 7-day heatmap of **deleted-per-day** counts
 (title says "Completed" — historical mislabel; buckets 0/1/2/3/4+ in blue shades, tap for
 snackbar, auto-scrolls to newest); (b) 365 daily stacked bars from `DailyTaskStats` —
@@ -539,7 +551,8 @@ rendering, most alarm/SMS runtime paths (verified on hardware + via alarm_log in
 11. Permissions that need dialogs are requested in the foreground only.
 12. Alarm channel changes require a new channel id (hence `_v2`).
 13. Kotlin folder/package mismatch is intentional; keep the committed debug keystore.
-14. `melody`/`volume`/`snoozeMaxCount` are stored-but-unused; keep serializing them.
+14. `snoozeMaxCount` is stored-but-unused; keep serializing it. (`melody`/`volume` are
+    implemented since 0.1.91 via the native `besttodo/alarm_audio` channel.)
 15. Stats heatmap counts deletions but is titled "Completed" — fix knowingly or keep.
 
 ---

--- a/android/app/src/main/kotlin/com/example/best_todo_2/AlarmSoundPlayer.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/AlarmSoundPlayer.kt
@@ -1,0 +1,209 @@
+package com.mfficiency.best_todo_2
+
+import android.app.NotificationManager
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import kotlin.math.PI
+import kotlin.math.min
+import kotlin.math.sin
+
+/**
+ * Plays the app's built-in alarm melodies at a caller-chosen loudness that is
+ * independent of the phone's current media / ringer / alarm volume.
+ *
+ * How the independence works: the melody is synthesized at full scale, played
+ * on the ALARM stream, and while it plays the alarm stream is raised to its
+ * maximum (the previous level is restored on [stop]). The requested volume
+ * (0.0–1.0) is then applied as the track gain, so "60%" always means 60% of
+ * the device's maximum alarm loudness no matter what the user last set their
+ * volume rockers to.
+ *
+ * Do Not Disturb: audio played with USAGE_ALARM is allowed through DND's
+ * priority modes by the system. When [overrideDnd] is false the caller asks us
+ * to respect DND, so nothing is played while any DND filter is active. When
+ * true we always play (adjusting the stream inside "total silence" can throw a
+ * SecurityException without notification-policy access — that is caught and
+ * playback proceeds at the current stream level as a best effort).
+ */
+object AlarmSoundPlayer {
+
+    private const val SAMPLE_RATE = 44100
+
+    private var track: AudioTrack? = null
+    private var restoreStreamVolume: Int = -1
+
+    /** One note of a melody: frequency in Hz (0 = rest) and duration in ms. */
+    private data class Note(val freq: Double, val ms: Int)
+
+    /**
+     * The built-in melodies, keyed by the names stored in the Dart `Alarm`
+     * model (`kAlarmMelodies`). Keep the keys stable once shipped.
+     */
+    private fun notesFor(melody: String): List<Note> = when (melody) {
+        "Chimes" -> listOf(
+            Note(1318.5, 250), Note(0.0, 60), Note(1046.5, 250), Note(0.0, 60),
+            Note(880.0, 250), Note(0.0, 60), Note(659.3, 400), Note(0.0, 700),
+        )
+        "Radar" -> listOf(
+            Note(1200.0, 90), Note(0.0, 90), Note(1200.0, 90), Note(0.0, 90),
+            Note(1200.0, 90), Note(0.0, 90), Note(1200.0, 90), Note(0.0, 600),
+        )
+        "Beacon" -> listOf(
+            Note(880.0, 700), Note(0.0, 900),
+        )
+        "Bells" -> listOf(
+            Note(784.0, 350), Note(0.0, 80), Note(784.0, 350), Note(0.0, 80),
+            Note(988.0, 500), Note(0.0, 600),
+        )
+        "Digital" -> listOf(
+            Note(2093.0, 70), Note(0.0, 50), Note(2093.0, 70), Note(0.0, 50),
+            Note(2093.0, 70), Note(0.0, 50), Note(2093.0, 70), Note(0.0, 400),
+        )
+        "Marimba" -> listOf(
+            Note(523.3, 180), Note(659.3, 180), Note(784.0, 180),
+            Note(1046.5, 300), Note(784.0, 180), Note(659.3, 180),
+            Note(523.3, 300), Note(0.0, 500),
+        )
+        // "Classic" and anything unknown.
+        else -> listOf(
+            Note(987.8, 180), Note(0.0, 90), Note(987.8, 180), Note(0.0, 90),
+            Note(987.8, 180), Note(0.0, 90), Note(987.8, 300), Note(0.0, 500),
+        )
+    }
+
+    /** Renders the melody's note list to one full-scale 16-bit PCM loop. */
+    private fun synthesize(melody: String): ShortArray {
+        val notes = notesFor(melody)
+        val totalSamples = notes.sumOf { it.ms * SAMPLE_RATE / 1000 }
+        val pcm = ShortArray(totalSamples)
+        var i = 0
+        for (note in notes) {
+            val samples = note.ms * SAMPLE_RATE / 1000
+            if (note.freq <= 0.0) {
+                i += samples // rest: leave zeros
+                continue
+            }
+            // Short attack/release ramps avoid clicks at note boundaries.
+            val ramp = min(samples / 4, SAMPLE_RATE / 100)
+            for (s in 0 until samples) {
+                val envelope = when {
+                    s < ramp -> s.toDouble() / ramp
+                    s > samples - ramp -> (samples - s).toDouble() / ramp
+                    else -> 1.0
+                }
+                val value =
+                    sin(2.0 * PI * note.freq * s / SAMPLE_RATE) * envelope
+                pcm[i + s] = (value * Short.MAX_VALUE * 0.9).toInt().toShort()
+            }
+            i += samples
+        }
+        return pcm
+    }
+
+    private fun isDndActive(context: Context): Boolean {
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE)
+            as NotificationManager
+        val filter = nm.currentInterruptionFilter
+        return filter != NotificationManager.INTERRUPTION_FILTER_ALL &&
+            filter != NotificationManager.INTERRUPTION_FILTER_UNKNOWN
+    }
+
+    /**
+     * Starts playing [melody] at [volume] (0.0–1.0 of the device maximum).
+     * Returns true when playback actually started; false when it was skipped
+     * (DND active and [overrideDnd] false) or failed.
+     */
+    @Synchronized
+    fun start(
+        context: Context,
+        melody: String,
+        volume: Double,
+        overrideDnd: Boolean,
+        loop: Boolean,
+    ): Boolean {
+        stop(context)
+        if (!overrideDnd && isDndActive(context)) return false
+
+        val pcm = synthesize(melody)
+        if (pcm.isEmpty()) return false
+
+        val audioManager =
+            context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        try {
+            // Pin the alarm stream to max for the duration of playback so the
+            // track gain below is the only thing deciding the loudness.
+            val current = audioManager.getStreamVolume(AudioManager.STREAM_ALARM)
+            val max = audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM)
+            if (current != max) {
+                restoreStreamVolume = current
+                audioManager.setStreamVolume(AudioManager.STREAM_ALARM, max, 0)
+            }
+        } catch (_: SecurityException) {
+            // DND "total silence" without notification-policy access: keep the
+            // stream as-is and still try to play.
+        } catch (_: Exception) {
+        }
+
+        return try {
+            val newTrack = AudioTrack.Builder()
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_ALARM)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
+                )
+                .setAudioFormat(
+                    AudioFormat.Builder()
+                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                        .setSampleRate(SAMPLE_RATE)
+                        .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                        .build()
+                )
+                .setTransferMode(AudioTrack.MODE_STATIC)
+                .setBufferSizeInBytes(pcm.size * 2)
+                .build()
+            newTrack.write(pcm, 0, pcm.size)
+            if (loop) {
+                newTrack.setLoopPoints(0, pcm.size, -1)
+            }
+            newTrack.setVolume(volume.coerceIn(0.0, 1.0).toFloat())
+            newTrack.play()
+            track = newTrack
+            true
+        } catch (_: Exception) {
+            restoreStreamLevel(context)
+            false
+        }
+    }
+
+    /** Stops playback and restores the alarm stream to its previous level. */
+    @Synchronized
+    fun stop(context: Context) {
+        try {
+            track?.stop()
+        } catch (_: Exception) {
+        }
+        try {
+            track?.release()
+        } catch (_: Exception) {
+        }
+        track = null
+        restoreStreamLevel(context)
+    }
+
+    private fun restoreStreamLevel(context: Context) {
+        if (restoreStreamVolume < 0) return
+        try {
+            val audioManager =
+                context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            audioManager.setStreamVolume(
+                AudioManager.STREAM_ALARM, restoreStreamVolume, 0
+            )
+        } catch (_: Exception) {
+        }
+        restoreStreamVolume = -1
+    }
+}

--- a/android/app/src/main/kotlin/com/example/best_todo_2/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/best_todo_2/MainActivity.kt
@@ -78,5 +78,32 @@ class MainActivity : FlutterActivity() {
                 else -> result.notImplemented()
             }
         }
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "besttodo/alarm_audio",
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                // Plays a built-in melody at an absolute loudness (fraction of
+                // the device maximum), independent of the current volume
+                // settings. Used by the full-screen ring page and the melody
+                // Preview button in the alarm editor.
+                "play" -> {
+                    val melody = call.argument<String>("melody") ?: "Classic"
+                    val volume = call.argument<Double>("volume") ?: 0.8
+                    val overrideDnd =
+                        call.argument<Boolean>("overrideDnd") ?: false
+                    val loop = call.argument<Boolean>("loop") ?: true
+                    val started = AlarmSoundPlayer.start(
+                        applicationContext, melody, volume, overrideDnd, loop
+                    )
+                    result.success(started)
+                }
+                "stop" -> {
+                    AlarmSoundPlayer.stop(applicationContext)
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
     }
 }

--- a/integration_test/home_page_screenshot_test.dart
+++ b/integration_test/home_page_screenshot_test.dart
@@ -90,7 +90,18 @@ void main() {
     await popCurrentPage();
     await tester.tap(find.byTooltip('Open navigation menu'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Your Stats'));
+    // Productivity Stats lives in the collapsible Tools section now.
+    await tester.tap(find.text('Tools'));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('Productivity Stats'),
+      80,
+      scrollable: find.descendant(
+        of: find.byType(Drawer),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    await tester.tap(find.text('Productivity Stats'));
     await tester.pumpAndSettle();
     await capture('your_stats_page');
   });

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -66,6 +66,34 @@ class Config {
   /// Home tab index shown when the app starts.
   static int startTabIndex = 0;
 
+  /// Pages selectable as the app's default start page: the task list plus
+  /// every tool. The keys are stored in settings, so keep them stable.
+  static const List<String> startToolOptions = [
+    'tasks',
+    'alarms',
+    'countdown',
+    'projects',
+    'chronize',
+    'usage_data',
+    'productivity_stats',
+  ];
+
+  /// Human-readable labels for [startToolOptions], index-aligned.
+  static const List<String> startToolLabels = [
+    'Task list',
+    'Alarms',
+    'Countdown',
+    'Projects',
+    'Chronize',
+    'Usage Data',
+    'Productivity Stats',
+  ];
+
+  /// Which page opens when the app starts: 'tasks' (the regular task list,
+  /// default) or one of the tools in [startToolOptions]. Tools open on top of
+  /// the task list, so backing out always lands on the tasks.
+  static String startTool = 'tasks';
+
   /// If true, the home page opens directly in the day-grouped schedule view
   /// instead of the per-tab list view.
   static bool startInScheduleView = false;
@@ -162,6 +190,7 @@ class Config {
       'defaultDelaySeconds': defaultDelaySeconds,
       'startInScheduleView': startInScheduleView,
       'chronizeShowHourWheel': chronizeShowHourWheel,
+      'startTool': startTool,
     };
   }
 
@@ -196,6 +225,10 @@ class Config {
     startInScheduleView = data['startInScheduleView'] ?? startInScheduleView;
     chronizeShowHourWheel =
         data['chronizeShowHourWheel'] ?? chronizeShowHourWheel;
+    final savedStartTool = data['startTool'] as String?;
+    if (savedStartTool != null && startToolOptions.contains(savedStartTool)) {
+      startTool = savedStartTool;
+    }
   }
 
   /// Persists the current settings to disk.

--- a/lib/models/alarm.dart
+++ b/lib/models/alarm.dart
@@ -48,6 +48,10 @@ class Alarm {
   /// Whether the device should vibrate when the alarm fires.
   bool vibrate;
 
+  /// When true the alarm rings at [volume] even while the phone is in
+  /// Do Not Disturb / silent mode or the alarm stream is turned down.
+  bool overrideDnd;
+
   /// Hour of day (0-23) the alarm fires.
   int hour;
 
@@ -85,6 +89,7 @@ class Alarm {
     this.volume = 0.8,
     this.melody = 'Classic',
     this.vibrate = true,
+    this.overrideDnd = false,
     this.hour = 8,
     this.minute = 0,
     this.date,
@@ -159,6 +164,7 @@ class Alarm {
       volume: (json['volume'] as num?)?.toDouble() ?? 0.8,
       melody: json['melody'] as String? ?? 'Classic',
       vibrate: json['vibrate'] as bool? ?? true,
+      overrideDnd: json['overrideDnd'] as bool? ?? false,
       hour: json['hour'] as int? ?? 8,
       minute: json['minute'] as int? ?? 0,
       date: json['date'] != null
@@ -184,6 +190,7 @@ class Alarm {
         'volume': volume,
         'melody': melody,
         'vibrate': vibrate,
+        'overrideDnd': overrideDnd,
         'hour': hour,
         'minute': minute,
         'date': date?.toIso8601String(),

--- a/lib/services/alarm_sound.dart
+++ b/lib/services/alarm_sound.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Bridge to the native alarm melody player (MainActivity).
+///
+/// The native side synthesizes the built-in melodies and plays them on the
+/// ALARM audio stream at an absolute loudness: `volume` is a fraction of the
+/// device's maximum, independent of whatever the media / ringer / alarm
+/// volume happens to be set to. With `overrideDnd` the melody also plays
+/// while Do Not Disturb is active; without it, playback is skipped under DND
+/// so the phone stays quiet.
+///
+/// Everything is a silent no-op on non-Android platforms and in widget tests
+/// (where the method channel has no host).
+class AlarmSound {
+  AlarmSound._();
+
+  static const MethodChannel _channel = MethodChannel('besttodo/alarm_audio');
+
+  static bool get _isAndroid =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+  /// Starts playing [melody] at [volume] (0.0–1.0 of the device maximum).
+  /// Returns true when playback actually started.
+  static Future<bool> play({
+    required String melody,
+    required double volume,
+    bool overrideDnd = false,
+    bool loop = true,
+  }) async {
+    if (!_isAndroid) return false;
+    try {
+      return await _channel.invokeMethod<bool>('play', <String, dynamic>{
+            'melody': melody,
+            'volume': volume.clamp(0.0, 1.0),
+            'overrideDnd': overrideDnd,
+            'loop': loop,
+          }) ??
+          false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Stops any playing melody and restores the previous alarm stream volume.
+  static Future<void> stop() async {
+    if (!_isAndroid) return;
+    try {
+      await _channel.invokeMethod<void>('stop');
+    } catch (_) {}
+  }
+}

--- a/lib/services/alarm_watchdog.dart
+++ b/lib/services/alarm_watchdog.dart
@@ -116,6 +116,9 @@ class AlarmWatchdog {
         vibrate: alarm.vibrate,
         notifIds: alarmNotificationIds(alarm.uid),
         fireAt: next,
+        melody: alarm.melody,
+        volume: alarm.volume,
+        overrideDnd: alarm.overrideDnd,
       );
       if (entry != null) registry['${alarmWatchdogId(alarm.uid)}'] = entry;
     }
@@ -131,6 +134,9 @@ class AlarmWatchdog {
     required String body,
     required bool vibrate,
     required DateTime fireAt,
+    String? melody,
+    double? volume,
+    bool overrideDnd = false,
   }) async {
     if (!await _ensureManager()) return;
     final prefs = await _prefs();
@@ -148,6 +154,9 @@ class AlarmWatchdog {
       notifIds: notifIds,
       fireAt: fireAt,
       label: 'snooze of ',
+      melody: melody,
+      volume: volume,
+      overrideDnd: overrideDnd,
     );
     if (entry != null) {
       registry['$id'] = entry;
@@ -184,6 +193,9 @@ class AlarmWatchdog {
     required List<int> notifIds,
     required DateTime fireAt,
     String label = '',
+    String? melody,
+    double? volume,
+    bool overrideDnd = false,
   }) async {
     final checkAt = fireAt.add(grace);
     try {
@@ -209,6 +221,9 @@ class AlarmWatchdog {
           'vibrate': vibrate,
           'notifIds': notifIds,
           'fireAt': fireAt.toIso8601String(),
+          if (melody != null) 'melody': melody,
+          if (volume != null) 'volume': volume,
+          'overrideDnd': overrideDnd,
         };
       }
       await AlarmLog.fail(
@@ -342,6 +357,9 @@ class AlarmWatchdog {
           body,
           vibrate: vibrate,
           uid: uid,
+          melody: entry['melody'] as String?,
+          volume: (entry['volume'] as num?)?.toDouble(),
+          overrideDnd: entry['overrideDnd'] as bool? ?? false,
         );
         if (shown) {
           await AlarmLog.ok('BACKUP', '"$title": backup ring posted');
@@ -378,6 +396,9 @@ class AlarmWatchdog {
         vibrate: alarm.vibrate,
         notifIds: alarmNotificationIds(uid),
         fireAt: next,
+        melody: alarm.melody,
+        volume: alarm.volume,
+        overrideDnd: alarm.overrideDnd,
       );
       if (newEntry != null) {
         final reg = _readRegistry(await _prefs());

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -65,15 +65,35 @@ class NotificationService {
 
   /// Shows an alarm alert immediately. Used by the watchdog backup path when
   /// an alarm's fire time was missed. With [uid] the notification carries the
-  /// alarm payload so the full-screen ring UI can open for it.
+  /// alarm payload so the full-screen ring UI can open for it. [melody],
+  /// [volume] and [overrideDnd] ride along in the payload so the ring UI can
+  /// play the alarm's own sound at its own loudness.
   static Future<bool> showAlarmNotification(
     String title,
     String body, {
     bool vibrate = true,
     String? uid,
+    String? melody,
+    double? volume,
+    bool overrideDnd = false,
   }) {
-    return impl.showAlarmNotification(title, body, vibrate: vibrate, uid: uid);
+    return impl.showAlarmNotification(
+      title,
+      body,
+      vibrate: vibrate,
+      uid: uid,
+      melody: melody,
+      volume: volume,
+      overrideDnd: overrideDnd,
+    );
   }
+
+  /// Moves a ringing alarm's notification onto a sound-less channel (keeping
+  /// its actions and vibration) once the full-screen ring UI has taken over
+  /// sound playback, so the channel's default sound and the alarm's melody
+  /// don't play on top of each other.
+  static Future<void> silenceAlarmNotification(Map<String, dynamic> payload) =>
+      impl.silenceAlarmNotification(payload);
 
   /// Registers the handler invoked (on the main isolate) with the alarm
   /// payload when a ringing alarm should present the full-screen ring UI.

--- a/lib/services/notification_service_impl_io.dart
+++ b/lib/services/notification_service_impl_io.dart
@@ -25,6 +25,13 @@ const String _channelDescription = 'Manual task notifications';
 const String _alarmChannelId = 'alarm_notifications_v2';
 const String _alarmChannelName = 'Alarms';
 const String _alarmChannelDescription = 'Alarm alerts';
+// Sound-less variant used while the app itself plays the alarm's melody (at
+// the alarm's own volume): the notification stays on screen with its actions
+// and keeps vibrating, but no longer plays the channel's default sound on top.
+const String _alarmSilentChannelId = 'alarm_notifications_silent_v1';
+const String _alarmSilentChannelName = 'Alarms (silent, in-app sound)';
+const String _alarmSilentChannelDescription =
+    'Alarm alerts whose sound is played by the app at the alarm\'s own volume';
 
 const String _snoozeAction = 'alarm_snooze';
 const String _dismissAction = 'alarm_dismiss';
@@ -89,6 +96,17 @@ Future<void> initialize() async {
           description: _alarmChannelDescription,
           importance: Importance.max,
           playSound: true,
+          enableVibration: true,
+          audioAttributesUsage: AudioAttributesUsage.alarm,
+        ),
+      );
+      await androidPlugin?.createNotificationChannel(
+        const AndroidNotificationChannel(
+          _alarmSilentChannelId,
+          _alarmSilentChannelName,
+          description: _alarmSilentChannelDescription,
+          importance: Importance.max,
+          playSound: false,
           enableVibration: true,
           audioAttributesUsage: AudioAttributesUsage.alarm,
         ),
@@ -247,6 +265,7 @@ Future<bool> ensureAlarmPermissions() async {
 AndroidNotificationDetails _androidAlarmDetails({
   required bool vibrate,
   required bool snoozeEnabled,
+  bool silent = false,
 }) {
   final actions = <AndroidNotificationAction>[
     if (snoozeEnabled)
@@ -263,15 +282,16 @@ AndroidNotificationDetails _androidAlarmDetails({
   ];
 
   return AndroidNotificationDetails(
-    _alarmChannelId,
-    _alarmChannelName,
-    channelDescription: _alarmChannelDescription,
+    silent ? _alarmSilentChannelId : _alarmChannelId,
+    silent ? _alarmSilentChannelName : _alarmChannelName,
+    channelDescription:
+        silent ? _alarmSilentChannelDescription : _alarmChannelDescription,
     importance: Importance.max,
     priority: Priority.max,
     category: AndroidNotificationCategory.alarm,
     fullScreenIntent: true,
     enableVibration: vibrate,
-    playSound: true,
+    playSound: !silent,
     ongoing: true,
     autoCancel: false,
     audioAttributesUsage: AudioAttributesUsage.alarm,
@@ -286,9 +306,11 @@ AndroidNotificationDetails _androidAlarmDetails({
 NotificationDetails _alarmDetails({
   required bool vibrate,
   required bool snoozeEnabled,
+  bool silent = false,
 }) {
   return NotificationDetails(
-    android: _androidAlarmDetails(vibrate: vibrate, snoozeEnabled: snoozeEnabled),
+    android: _androidAlarmDetails(
+        vibrate: vibrate, snoozeEnabled: snoozeEnabled, silent: silent),
     iOS: const DarwinNotificationDetails(
       presentAlert: true,
       presentSound: true,
@@ -307,6 +329,9 @@ String _payloadFor(Alarm alarm) => jsonEncode({
       'snoozeMinutes': alarm.snoozeDurationMinutes,
       'snoozeId': alarmNotificationBaseId(alarm.uid),
       'color': alarm.color,
+      'melody': alarm.melody,
+      'volume': alarm.volume,
+      'overrideDnd': alarm.overrideDnd,
     });
 
 /// Parses a notification payload and returns it when it belongs to an alarm
@@ -719,6 +744,9 @@ Future<void> _scheduleSnoozeFromData(
       body: data['body'] as String? ?? '',
       vibrate: data['vibrate'] as bool? ?? true,
       fireAt: when,
+      melody: data['melody'] as String?,
+      volume: (data['volume'] as num?)?.toDouble(),
+      overrideDnd: data['overrideDnd'] as bool? ?? false,
     );
   }
 }
@@ -798,6 +826,9 @@ Future<bool> showAlarmNotification(
   String body, {
   bool vibrate = true,
   String? uid,
+  String? melody,
+  double? volume,
+  bool overrideDnd = false,
 }) async {
   final hasPermission = await _ensurePermission();
   if (!hasPermission) return false;
@@ -822,6 +853,9 @@ Future<bool> showAlarmNotification(
           'snoozeEnabled': false,
           'snoozeMinutes': 9,
           'snoozeId': baseId,
+          if (melody != null) 'melody': melody,
+          if (volume != null) 'volume': volume,
+          'overrideDnd': overrideDnd,
         });
   await _plugin.show(
     id,
@@ -831,6 +865,53 @@ Future<bool> showAlarmNotification(
     payload: payload,
   );
   return true;
+}
+
+/// Moves a ringing alarm's notification onto the sound-less channel: the
+/// notification (with its Snooze/Dismiss actions and looping vibration) stays
+/// on screen, but the channel's default alarm sound stops. Called by the
+/// full-screen ring page once it has started playing the alarm's own melody
+/// at the alarm's own volume, so the two sounds don't stack.
+Future<void> silenceAlarmNotification(Map<String, dynamic> data) async {
+  if (!Platform.isAndroid) return;
+  await initialize();
+  final uid = data['uid'] as String? ?? '';
+  if (uid.isEmpty) return;
+  final ids = uid == kTestAlarmUid
+      ? <int>{kTestAlarmNotificationId}
+      : alarmNotificationIds(uid).toSet();
+  try {
+    final active = await _plugin.getActiveNotifications();
+    var replaced = false;
+    for (final n in active) {
+      final id = n.id;
+      if (id == null || !ids.contains(id)) continue;
+      await _plugin.cancel(id);
+      if (replaced) continue;
+      replaced = true;
+      final body = data['body'] as String? ?? '';
+      await _plugin.show(
+        id,
+        data['name'] as String? ?? 'Alarm',
+        body.isEmpty ? null : body,
+        _alarmDetails(
+          vibrate: data['vibrate'] as bool? ?? true,
+          snoozeEnabled: data['snoozeEnabled'] as bool? ?? false,
+          silent: true,
+        ),
+        payload: jsonEncode(data),
+      );
+    }
+    if (replaced) {
+      await AlarmLog.info(
+          'ACTION',
+          '"${data['name'] ?? 'Alarm'}": notification sound handed over to '
+          'in-app melody playback');
+    }
+  } catch (e) {
+    await AlarmLog.warn(
+        'ACTION', 'could not silence the ringing notification: $e');
+  }
 }
 
 Future<void> _showNow(String taskTitle) async {

--- a/lib/services/notification_service_impl_stub.dart
+++ b/lib/services/notification_service_impl_stub.dart
@@ -14,9 +14,14 @@ Future<bool> showAlarmNotification(
   String body, {
   bool vibrate = true,
   String? uid,
+  String? melody,
+  double? volume,
+  bool overrideDnd = false,
 }) async {
   return false;
 }
+
+Future<void> silenceAlarmNotification(Map<String, dynamic> payload) async {}
 
 void Function(Map<String, dynamic> payload)? onAlarmRing;
 

--- a/lib/services/notification_service_impl_web.dart
+++ b/lib/services/notification_service_impl_web.dart
@@ -40,6 +40,9 @@ Future<bool> showAlarmNotification(
   String body, {
   bool vibrate = true,
   String? uid,
+  String? melody,
+  double? volume,
+  bool overrideDnd = false,
 }) async {
   final hasPermission = await _ensurePermission();
   if (!hasPermission) return false;
@@ -47,6 +50,8 @@ Future<bool> showAlarmNotification(
   html.Notification(safeTitle, body: body.isEmpty ? null : body);
   return true;
 }
+
+Future<void> silenceAlarmNotification(Map<String, dynamic> payload) async {}
 
 Future<bool> ensureAlarmPermissions() async => _ensurePermission();
 

--- a/lib/ui/alarm_edit_page.dart
+++ b/lib/ui/alarm_edit_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/alarm.dart';
+import '../services/alarm_sound.dart';
 import 'subpage_app_bar.dart';
 
 /// Full screen editor for creating or editing an [Alarm].
@@ -25,6 +26,9 @@ class _AlarmEditPageState extends State<AlarmEditPage> {
   late final TextEditingController _nameController;
   late final TextEditingController _descriptionController;
 
+  /// Whether the melody preview is currently playing.
+  bool _previewing = false;
+
   static const List<String> _weekdayNames = [
     'Mon',
     'Tue',
@@ -46,9 +50,54 @@ class _AlarmEditPageState extends State<AlarmEditPage> {
 
   @override
   void dispose() {
+    // Leaving the editor in any way (save, delete, back) ends the preview.
+    AlarmSound.stop();
     _nameController.dispose();
     _descriptionController.dispose();
     super.dispose();
+  }
+
+  /// Starts/stops the melody preview: the selected melody, played exactly the
+  /// way the alarm will ring — at the configured alarm volume, independent of
+  /// the phone's current volume settings — so both the sound and the loudness
+  /// can be checked before saving.
+  ///
+  /// The platform call is intentionally not awaited for the button state: on
+  /// hosts without the audio channel the reply may never arrive, and the UI
+  /// must not hang on it. When the call reports it could not start, the state
+  /// is rolled back and a hint is shown.
+  void _togglePreview() {
+    if (_previewing) {
+      AlarmSound.stop();
+      setState(() => _previewing = false);
+      return;
+    }
+    setState(() => _previewing = true);
+    AlarmSound.play(
+      melody: _draft.melody,
+      volume: _draft.volume,
+      // The user explicitly asked to hear it, so play even under DND.
+      overrideDnd: true,
+      loop: true,
+    ).then((started) {
+      if (started || !mounted || !_previewing) return;
+      setState(() => _previewing = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Melody preview is only available on Android')),
+      );
+    });
+  }
+
+  /// While the preview is playing, apply melody/volume changes to it live.
+  void _refreshPreview() {
+    if (!_previewing) return;
+    AlarmSound.play(
+      melody: _draft.melody,
+      volume: _draft.volume,
+      overrideDnd: true,
+      loop: true,
+    );
   }
 
   Future<void> _pickTime() async {
@@ -236,8 +285,19 @@ class _AlarmEditPageState extends State<AlarmEditPage> {
                     for (final melody in kAlarmMelodies)
                       DropdownMenuItem(value: melody, child: Text(melody)),
                   ],
-                  onChanged: (v) =>
-                      setState(() => _draft.melody = v ?? _draft.melody),
+                  onChanged: (v) {
+                    setState(() => _draft.melody = v ?? _draft.melody);
+                    _refreshPreview();
+                  },
+                ),
+                IconButton(
+                  icon: Icon(
+                    _previewing
+                        ? Icons.stop_circle_outlined
+                        : Icons.play_circle_outlined,
+                  ),
+                  tooltip: _previewing ? 'Stop preview' : 'Preview',
+                  onPressed: _togglePreview,
                 ),
               ],
             ),
@@ -250,6 +310,7 @@ class _AlarmEditPageState extends State<AlarmEditPage> {
                 child: Slider(
                   value: _draft.volume.clamp(0.0, 1.0),
                   onChanged: (v) => setState(() => _draft.volume = v),
+                  onChangeEnd: (_) => _refreshPreview(),
                 ),
               ),
               SizedBox(
@@ -259,12 +320,30 @@ class _AlarmEditPageState extends State<AlarmEditPage> {
               ),
             ],
           ),
+          Padding(
+            padding: const EdgeInsets.only(left: 40, bottom: 8),
+            child: Text(
+              'The alarm rings at this loudness, independent of the '
+              'phone\'s current volume',
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
           SwitchListTile(
             contentPadding: EdgeInsets.zero,
             secondary: const Icon(Icons.vibration),
             title: const Text('Vibrate'),
             value: _draft.vibrate,
             onChanged: (v) => setState(() => _draft.vibrate = v),
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            secondary: const Icon(Icons.do_not_disturb_on),
+            title: const Text('Override Do Not Disturb'),
+            subtitle: const Text(
+                'Always ring at the volume set above, even when the phone '
+                'is silenced or in Do Not Disturb'),
+            value: _draft.overrideDnd,
+            onChanged: (v) => setState(() => _draft.overrideDnd = v),
           ),
           const Divider(),
 

--- a/lib/ui/alarm_ring_page.dart
+++ b/lib/ui/alarm_ring_page.dart
@@ -3,14 +3,22 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../services/alarm_fullscreen.dart';
+import '../services/alarm_sound.dart';
 import '../services/notification_service.dart';
 
 /// Full-screen alarm screen shown while an alarm is ringing — the same idea
 /// as the Google/Samsung clock apps: it covers the whole screen (over the
 /// lock screen when launched by the alarm's full-screen intent), shows a live
-/// clock and the alarm's name, and offers big Snooze / Stop actions. The
-/// sound and vibration come from the insistent alarm notification, so they
-/// keep going until one of the actions here (or on the notification) is used.
+/// clock and the alarm's name, and offers big Snooze / Stop actions.
+///
+/// Sound: when the payload carries the alarm's melody/volume, this page plays
+/// that melody at the alarm's own volume — independent of the phone's volume
+/// settings, and (with the alarm's Override Do Not Disturb switch) through
+/// DND — and hands the notification over to a silent channel so the default
+/// channel sound doesn't stack on top. Vibration keeps coming from the
+/// insistent notification. When the melody can't be played (old payloads,
+/// non-Android), the insistent notification's default sound keeps ringing as
+/// before.
 class AlarmRingPage extends StatefulWidget {
   /// Decoded alarm notification payload (uid, name, body, snooze settings,
   /// color) — the same JSON the notification actions receive.
@@ -65,12 +73,36 @@ class _AlarmRingPageState extends State<AlarmRingPage>
       lowerBound: 0.9,
       upperBound: 1.1,
     )..repeat(reverse: true);
+    _startMelody();
+  }
+
+  /// Plays the alarm's own melody at the alarm's own volume and, once that
+  /// audibly runs, moves the notification onto the silent channel so the
+  /// default channel sound stops. No-op for payloads without a melody (posted
+  /// by older builds) — those keep the notification's default sound.
+  Future<void> _startMelody() async {
+    final melody = widget.payload['melody'] as String?;
+    if (melody == null || melody.isEmpty) return;
+    final volume = (widget.payload['volume'] as num?)?.toDouble() ?? 0.8;
+    final overrideDnd = widget.payload['overrideDnd'] as bool? ?? false;
+    final started = await AlarmSound.play(
+      melody: melody,
+      volume: volume,
+      overrideDnd: overrideDnd,
+      loop: true,
+    );
+    if (started) {
+      await NotificationService.silenceAlarmNotification(widget.payload);
+    }
   }
 
   @override
   void dispose() {
     _clockTimer.cancel();
     _pulse.dispose();
+    // Safety net: the actions already stop the melody, but the page can also
+    // go away without one (e.g. the whole route stack is torn down).
+    AlarmSound.stop();
     // The activity may be showing over the lock screen because the alarm's
     // full-screen intent launched it; drop that as soon as the ring UI goes
     // away so the rest of the app stays behind the keyguard.
@@ -82,6 +114,9 @@ class _AlarmRingPageState extends State<AlarmRingPage>
       Future<void> Function(Map<String, dynamic> payload) action) async {
     if (_busy) return;
     setState(() => _busy = true);
+    // Fire-and-forget: stopping the melody must not delay (or, in tests with
+    // no platform channel host, block) the dismiss/snooze action itself.
+    AlarmSound.stop();
     try {
       await action(widget.payload);
     } catch (_) {}

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -664,8 +664,68 @@ class _HomePageState extends State<HomePage>
     // Project names are shown as tags on task tiles, so load them here and
     // not only when the Projects tool is opened.
     ProjectService.instance.load();
-    _loadTasks();
+    // Some tools (Chronize, Productivity Stats, ...) render the task data, so
+    // the configured start tool is only opened once loading finished.
+    _loadTasks().then((_) => _maybeOpenStartTool());
     _scheduleMidnightUpdate();
+  }
+
+  /// The page for a tool key from [Config.startToolOptions]; null for
+  /// 'tasks' (the home page itself) and unknown keys.
+  Widget? _buildToolPage(String tool) {
+    switch (tool) {
+      case 'alarms':
+        return const AlarmsPage();
+      case 'countdown':
+        return const CountdownTimerPage();
+      case 'projects':
+        return ProjectsPage(tasks: _tasks, onChanged: _saveTasks);
+      case 'chronize':
+        return ChronizePage(
+          tasks: _tasks,
+          onCreateTask: _addTaskFromChronize,
+          onTaskChanged: _onChronizeTaskChanged,
+          onDeleteTask: _deleteTaskFromChronize,
+        );
+      case 'usage_data':
+        return UsageDataPage(
+          tasks: _tasks,
+          deletedTasks: _deletedTasks,
+          dailyStatsByDay: _dailyStatsByDay,
+        );
+      case 'productivity_stats':
+        return YourStatsPage(
+          tasks: _tasks,
+          deletedItems: _deletedTasks,
+          dailyStatsByDay: _dailyStatsByDay,
+        );
+    }
+    return null;
+  }
+
+  /// Pushes the given tool's page. Used by the Tools drawer section and by
+  /// the "Default start page" setting on launch.
+  void _openTool(String tool) {
+    final page = _buildToolPage(tool);
+    if (page == null) return;
+    Navigator.of(context)
+        .push(MaterialPageRoute(builder: (_) => page))
+        .then((_) {
+      // Tools like Projects mutate tasks in place; refresh the lists when
+      // coming back.
+      if (mounted) setState(() {});
+    });
+  }
+
+  /// Opens the tool configured as the default start page (if any) on top of
+  /// the task list, so backing out of it lands on the tasks as usual.
+  void _maybeOpenStartTool() {
+    if (Config.startTool == 'tasks') return;
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _openTool(Config.startTool);
+    });
   }
 
   @override
@@ -1647,22 +1707,6 @@ class _HomePageState extends State<HomePage>
               },
             ),
             ListTile(
-              leading: const Icon(Icons.insights),
-              title: const Text('Your Stats'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => YourStatsPage(
-                      tasks: _tasks,
-                      deletedItems: _deletedTasks,
-                      dailyStatsByDay: _dailyStatsByDay,
-                    ),
-                  ),
-                );
-              },
-            ),
-            ListTile(
               leading: const Icon(Icons.info),
               title: const Text('About'),
               onTap: () {
@@ -1712,9 +1756,7 @@ class _HomePageState extends State<HomePage>
                   title: const Text('Alarms'),
                   onTap: () {
                     Navigator.pop(context);
-                    Navigator.of(context).push(
-                      MaterialPageRoute(builder: (_) => const AlarmsPage()),
-                    );
+                    _openTool('alarms');
                   },
                 ),
                 ListTile(
@@ -1722,11 +1764,7 @@ class _HomePageState extends State<HomePage>
                   title: const Text('Countdown'),
                   onTap: () {
                     Navigator.pop(context);
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => const CountdownTimerPage(),
-                      ),
-                    );
+                    _openTool('countdown');
                   },
                 ),
                 ListTile(
@@ -1734,16 +1772,7 @@ class _HomePageState extends State<HomePage>
                   title: const Text('Projects'),
                   onTap: () {
                     Navigator.pop(context);
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => ProjectsPage(
-                          tasks: _tasks,
-                          onChanged: _saveTasks,
-                        ),
-                      ),
-                    ).then((_) {
-                      if (mounted) setState(() {});
-                    });
+                    _openTool('projects');
                   },
                 ),
                 ListTile(
@@ -1751,16 +1780,15 @@ class _HomePageState extends State<HomePage>
                   title: const Text('Chronize'),
                   onTap: () {
                     Navigator.pop(context);
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => ChronizePage(
-                        tasks: _tasks,
-                        onCreateTask: _addTaskFromChronize,
-                        onTaskChanged: _onChronizeTaskChanged,
-                        onDeleteTask: _deleteTaskFromChronize,
-                      ),
-                      ),
-                    );
+                    _openTool('chronize');
+                  },
+                ),
+                ListTile(
+                  leading: const Icon(Icons.insights),
+                  title: const Text('Productivity Stats'),
+                  onTap: () {
+                    Navigator.pop(context);
+                    _openTool('productivity_stats');
                   },
                 ),
                 ListTile(
@@ -1768,15 +1796,7 @@ class _HomePageState extends State<HomePage>
                   title: const Text('Usage Data'),
                   onTap: () {
                     Navigator.pop(context);
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => UsageDataPage(
-                          tasks: _tasks,
-                          deletedTasks: _deletedTasks,
-                          dailyStatsByDay: _dailyStatsByDay,
-                        ),
-                      ),
-                    );
+                    _openTool('usage_data');
                   },
                 ),
               ],

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -57,6 +57,7 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _use24HourFormat = Config.use24HourFormat;
   String _dateFormat = Config.dateFormat;
   int _startTabIndex = Config.startTabIndex;
+  String _startTool = Config.startTool;
   bool _startInScheduleView = Config.startInScheduleView;
   bool _chronizeShowHourWheel = Config.chronizeShowHourWheel;
   double _defaultDelaySeconds = Config.defaultDelaySeconds;
@@ -78,6 +79,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _use24HourFormat = Config.use24HourFormat;
     _dateFormat = Config.dateFormat;
     _startTabIndex = Config.startTabIndex;
+    _startTool = Config.startTool;
     _startInScheduleView = Config.startInScheduleView;
     _chronizeShowHourWheel = Config.chronizeShowHourWheel;
     _defaultDelaySeconds = Config.defaultDelaySeconds;
@@ -910,6 +912,31 @@ class _SettingsPageState extends State<SettingsPage> {
                             if (val == null) return;
                             setState(() => _startTabIndex = val);
                             Config.startTabIndex = val;
+                            await Config.save();
+                            widget.onSettingsChanged?.call();
+                          },
+                        ),
+                      ),
+                      ListTile(
+                        title: const Text('Default start page'),
+                        subtitle: const Text(
+                            'Open the task list or one of the tools when '
+                            'launching the app'),
+                        trailing: DropdownButton<String>(
+                          value: Config.startToolOptions.contains(_startTool)
+                              ? _startTool
+                              : Config.startToolOptions.first,
+                          items: List.generate(
+                            Config.startToolOptions.length,
+                            (index) => DropdownMenuItem<String>(
+                              value: Config.startToolOptions[index],
+                              child: Text(Config.startToolLabels[index]),
+                            ),
+                          ),
+                          onChanged: (val) async {
+                            if (val == null) return;
+                            setState(() => _startTool = val);
+                            Config.startTool = val;
                             await Config.save();
                             widget.onSettingsChanged?.call();
                           },

--- a/lib/ui/your_stats_page.dart
+++ b/lib/ui/your_stats_page.dart
@@ -780,7 +780,7 @@ class _YourStatsPageState extends State<YourStatsPage>
     return Scaffold(
       appBar: buildSubpageAppBar(
         context,
-        title: 'Your Stats',
+        title: 'Productivity Stats',
         bottom: PreferredSize(
           preferredSize: Size.fromHeight(Config.isDev ? 52 : 0),
           child: Column(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.89+59
+version: 0.1.91+60
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/alarm_edit_page_test.dart
+++ b/test/alarm_edit_page_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:besttodo/models/alarm.dart';
+import 'package:besttodo/ui/alarm_edit_page.dart';
+
+void main() {
+  Future<void> pumpEditor(WidgetTester tester, {Alarm? alarm}) async {
+    await tester.pumpWidget(MaterialApp(home: AlarmEditPage(alarm: alarm)));
+    await tester.pumpAndSettle();
+  }
+
+  // The editor is one ListView; the TextFields inside it have their own
+  // Scrollables, so scrolling must target the ListView explicitly.
+  Future<void> revealInEditor(WidgetTester tester, Finder finder) async {
+    await tester.dragUntilVisible(
+      finder,
+      find.byType(ListView),
+      const Offset(0, -120),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('editor shows the Override Do Not Disturb toggle (off default)',
+      (tester) async {
+    await pumpEditor(tester);
+
+    final finder = find.text('Override Do Not Disturb');
+    await revealInEditor(tester, finder);
+    expect(finder, findsOneWidget);
+
+    final tile = tester.widget<SwitchListTile>(
+      find.ancestor(of: finder, matching: find.byType(SwitchListTile)),
+    );
+    expect(tile.value, isFalse);
+  });
+
+  testWidgets('melody Preview button toggles between play and stop',
+      (tester) async {
+    await pumpEditor(tester);
+
+    final preview = find.byTooltip('Preview');
+    await revealInEditor(tester, preview);
+    expect(preview, findsOneWidget);
+
+    // Start the preview: the button flips to its stop state. (In tests the
+    // platform channel has no host, so nothing actually plays.)
+    await tester.tap(preview);
+    await tester.pump();
+    expect(find.byTooltip('Stop preview'), findsOneWidget);
+
+    // Stop it again.
+    await tester.tap(find.byTooltip('Stop preview'));
+    await tester.pump();
+    expect(find.byTooltip('Preview'), findsOneWidget);
+  });
+
+  testWidgets('saving keeps the Override Do Not Disturb choice',
+      (tester) async {
+    Object? result;
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => Center(
+          child: ElevatedButton(
+            onPressed: () async {
+              result = await Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => AlarmEditPage(
+                    alarm: Alarm(name: 'Wake up', volume: 0.6),
+                  ),
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final toggle = find.text('Override Do Not Disturb');
+    await tester.dragUntilVisible(
+      toggle,
+      find.byType(ListView),
+      const Offset(0, -120),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(toggle);
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Save'));
+    await tester.pumpAndSettle();
+
+    expect(result, isA<Alarm>());
+    final saved = result as Alarm;
+    expect(saved.overrideDnd, isTrue);
+    expect(saved.volume, 0.6);
+    expect(saved.name, 'Wake up');
+  });
+}

--- a/test/alarm_edit_save_top_test.dart
+++ b/test/alarm_edit_save_top_test.dart
@@ -67,6 +67,11 @@ void main() {
     // private FilledButton subtype that find.byType would miss).
     await tester.scrollUntilVisible(find.text('Save'), 100,
         scrollable: find.byType(Scrollable).first);
+    // scrollUntilVisible stops as soon as the button BUILDS, which (in a lazy
+    // ListView with cache extent) can still be off-screen — a tap there would
+    // silently miss. Make sure it is actually on screen first.
+    await tester.ensureVisible(find.text('Save'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 

--- a/test/alarm_model_test.dart
+++ b/test/alarm_model_test.dart
@@ -23,6 +23,7 @@ void main() {
       volume: 0.5,
       melody: 'Radar',
       vibrate: false,
+      overrideDnd: true,
       hour: 6,
       minute: 30,
       date: date,
@@ -42,6 +43,7 @@ void main() {
     expect(decoded.volume, 0.5);
     expect(decoded.melody, 'Radar');
     expect(decoded.vibrate, isFalse);
+    expect(decoded.overrideDnd, isTrue);
     expect(decoded.hour, 6);
     expect(decoded.minute, 30);
     expect(decoded.date, date);
@@ -52,6 +54,13 @@ void main() {
     expect(decoded.snoozeDurationMinutes, 5);
     expect(decoded.snoozeMaxCount, 2);
     expect(decoded.enabled, isFalse);
+  });
+
+  test('overrideDnd defaults to off, also for stored alarms without it', () {
+    expect(Alarm(name: 'plain').overrideDnd, isFalse);
+    // Alarms saved by builds that pre-date the field.
+    final legacy = Alarm(name: 'legacy').toJson()..remove('overrideDnd');
+    expect(Alarm.fromJson(legacy).overrideDnd, isFalse);
   });
 
   test('scheduleLabel summarizes repeat days', () {

--- a/test/config_persistence_test.dart
+++ b/test/config_persistence_test.dart
@@ -27,6 +27,7 @@ void main() {
     Config.defaultDelaySeconds = 7.5;
     Config.use24HourFormat = false;
     Config.dateFormat = 'yyyy-MM-dd';
+    Config.startTool = 'productivity_stats';
     await Config.save();
 
     // Reset to defaults
@@ -38,6 +39,7 @@ void main() {
     Config.defaultDelaySeconds = 5.0;
     Config.use24HourFormat = true;
     Config.dateFormat = Config.dateFormats.first;
+    Config.startTool = 'tasks';
 
     await Config.load();
 
@@ -49,6 +51,19 @@ void main() {
     expect(Config.defaultDelaySeconds, 7.5);
     expect(Config.use24HourFormat, isFalse);
     expect(Config.dateFormat, 'yyyy-MM-dd');
+    expect(Config.startTool, 'productivity_stats');
+  });
+
+  test('unknown startTool values are ignored on load', () {
+    Config.startTool = 'tasks';
+    Config.applyMap({'startTool': 'does_not_exist'});
+    expect(Config.startTool, 'tasks');
+
+    Config.applyMap({'startTool': 'chronize'});
+    expect(Config.startTool, 'chronize');
+
+    // Restore the default so other tests see a clean config.
+    Config.startTool = 'tasks';
   });
 }
 

--- a/tool/update_screenshot_changelog.dart
+++ b/tool/update_screenshot_changelog.dart
@@ -32,7 +32,7 @@ void main(List<String> args) {
     ..writeln(
         '![$now - $safeBranch - settings]($screenshotFolder/settings_page.png)')
     ..writeln()
-    ..writeln('### Your Stats')
+    ..writeln('### Productivity Stats')
     ..writeln(
         '![$now - $safeBranch - stats]($screenshotFolder/your_stats_page.png)')
     ..writeln()


### PR DESCRIPTION
## Summary

Builds on `dev` (0.1.91+61; latest `dev` merged in):

### Productivity Stats
- Renamed **Your Stats** → **Productivity Stats** (drawer entry + page title) and moved it into the **Tools** section of the menu, next to Alarms, Countdown, Projects, Chronize and Usage Data. Screenshot integration test updated to match.

### Settings: default start page
- New **"Default start page"** dropdown in Settings → Tasks listing the task list plus every tool (Alarms, Countdown, Projects, Chronize, Usage Data, Productivity Stats).
- Persisted as `Config.startTool` (round-trips through settings export/import; unknown values ignored). On launch, the chosen tool opens on top of the task list once task data has loaded, so back always returns to the tasks.

### Alarms
- **Per-alarm volume is now real.** New native `AlarmSoundPlayer.kt` (driven via a `besttodo/alarm_audio` MethodChannel) synthesizes the built-in melodies and plays them on the ALARM stream with the stream pinned to max during playback (previous level restored on stop) and the alarm's volume applied as track gain — each alarm rings at its configured fraction of the device maximum, independent of the phone's current media/ringer/alarm volume.
- **Override Do Not Disturb** switch per alarm (new persisted `overrideDnd` field): on, the alarm always plays at its configured volume, even while the phone is silenced or in DND; off, DND is respected.
- **Preview button** next to the melody picker plays the selected melody at the configured alarm volume and live-updates while changing melody or volume, so sound and loudness can be verified before saving.
- While the full-screen ring page plays the alarm's own melody, the notification is handed to a new silent channel (`alarm_notifications_silent_v1`, actions + vibration stay) so the default channel sound no longer stacks on top. If melody playback cannot start, the loud insistent notification keeps ringing — the scheduling ladder and delivery watchdog are untouched, and melody/volume/override now ride through snoozes and watchdog backup rings.

## Testing
- `flutter analyze`: no new issues.
- `flutter test`: **114/114 passing** locally on Flutter 3.29.2 after merging the latest `dev` (including its startup-times test fix and the new search/projects tests).
- New tests: alarm editor Override-DND toggle + preview button + save round-trip, `overrideDnd` model serialization (incl. legacy JSON), `startTool` persistence/validation.
- One dev test hardened: `alarm_edit_save_top_test.dart` now scrolls the bottom Save button fully on screen before tapping (the longer editor form exposed a lazy-ListView cache-extent miss).
- Both Kotlin files compile against the Android 14 framework + Flutter 3.29.2 embedding (verified with a standalone compiler, since the APK workflow doesn't run on feature branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVJVS9KmxRpc1GzgUL4Hzk