### PR TITLE
Add dice timer: rotary egg-timer for random task selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.94] - 2026-07-09
+- New dice button in the app bar (right of the search field): rolls one of today's open tasks at random and opens a rotary egg-timer for it — wind the dial to the wanted minutes and the countdown starts the moment you let go, showing the time left and the wall-clock end time
+- Dice timer: at zero an alarm rings and the task can be confirmed Done, postponed to tomorrow, or given extra time (+1 / +5 / +10 min); grabbing the dial mid-countdown pauses and rewinds it
+
 ## [0.1.93] - 2026-07-08
 - Stats renamed to Productivity Stats and moved into the Tools section of the menu
 - Settings: choose the default start page — the task list or any tool (Alarms, Countdown, Projects, Chronize, Usage Data, Productivity Stats); the chosen tool opens on launch, back returns to the task list

--- a/SPEC.md
+++ b/SPEC.md
@@ -229,6 +229,24 @@ while searching and `_saveTasks` renumbers `listRanking` from the UNfiltered tab
 (`_tasksForTab(i, applySearch: false)`) — otherwise a save during search would scramble
 hidden tasks' order.
 
+**Dice timer (0.1.94):** a dice app-bar action (`Icons.casino`, tooltip "Roll a random
+task timer", immediately right of the search field) picks a random open (not done) task
+from the Today tab — ignoring any active search — and pushes `DiceTimerPage`
+(`lib/ui/dice_timer_page.dart`). The page shows the rolled task above a rotary egg-timer
+dial (`DiceTimerDial`, one full turn = 60 min, whole-minute snapping): winding uses raw
+pointer events (a `Listener`, NOT a pan recognizer — an ancestor scrollable would win
+mostly-vertical drags in the gesture arena), with `dialAngle`/`dialAngleDelta` keeping the
+rotation continuous across 12 o'clock. Releasing the dial starts the countdown (a 1 s
+decrementing ticker, deliberately not wall-clock-anchored so tests can fake-pump it) and
+shows the remaining time plus the wall-clock end time ("Ends at 14:32"). Grabbing the dial
+mid-countdown (or mid-ring) pauses/silences and rounds up to whole minutes for rewinding.
+At zero it plays the 'Classic' alarm melody (loop, 0.8 volume) + a task notification
+(both best-effort; injectable via `onRingAlert` for tests) and offers: **Done** (marks the
+task done via the home page callback), **Postpone to tomorrow** (same semantics as moving
+to the Tomorrow tab, including recurrence detach), and **+1/+5/+10 min** (stops the ring
+and restarts the countdown with that much time). With no open Today tasks the dice shows a
+"No open tasks for today" snackbar instead.
+
 **Home widget updates** after every save and at a self-rescheduling midnight timer: writes
 the "due today or overdue" list text (or "Well done! No more tasks for today!"), a progress
 percent, and a color (green all done / orange exactly 4 left / red ≥5 left).

--- a/lib/ui/dice_timer_page.dart
+++ b/lib/ui/dice_timer_page.dart
@@ -1,0 +1,504 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../models/task.dart';
+import '../services/alarm_sound.dart';
+import '../services/log_service.dart';
+import '../services/notification_service.dart';
+import 'subpage_app_bar.dart';
+
+/// Angle of [point] around [center] in radians, measured clockwise from
+/// 12 o'clock, normalized to `[0, 2π)`.
+double dialAngle(Offset center, Offset point) {
+  final angle = math.atan2(point.dx - center.dx, center.dy - point.dy);
+  return angle < 0 ? angle + 2 * math.pi : angle;
+}
+
+/// Signed shortest way around the dial from [from] to [to], in radians
+/// (positive = clockwise). Keeps a drag continuous when the finger crosses
+/// the 12 o'clock boundary instead of jumping a full turn.
+double dialAngleDelta(double from, double to) {
+  var delta = to - from;
+  while (delta > math.pi) {
+    delta -= 2 * math.pi;
+  }
+  while (delta < -math.pi) {
+    delta += 2 * math.pi;
+  }
+  return delta;
+}
+
+/// The dice timer's three states: winding the dial, counting down, and
+/// ringing at zero.
+enum DiceTimerPhase { setting, running, ringing }
+
+/// Egg-timer page for a randomly rolled task: wind the rotary dial to the
+/// wanted duration, let go and the countdown starts (showing the wall-clock
+/// end time). At zero an alarm rings and the task can be confirmed done,
+/// postponed to tomorrow, or given some extra time.
+class DiceTimerPage extends StatefulWidget {
+  /// The task the dice landed on.
+  final Task task;
+
+  /// Called when the user confirms the task is done at (or after) the ring.
+  final VoidCallback onTaskDone;
+
+  /// Called when the user postpones the task to tomorrow at the ring.
+  final VoidCallback onTaskPostponed;
+
+  /// Overridable ring side-effect (for tests); defaults to playing the alarm
+  /// melody and posting a notification.
+  final Future<void> Function(Task task)? onRingAlert;
+
+  const DiceTimerPage({
+    Key? key,
+    required this.task,
+    required this.onTaskDone,
+    required this.onTaskPostponed,
+    this.onRingAlert,
+  }) : super(key: key);
+
+  @override
+  State<DiceTimerPage> createState() => _DiceTimerPageState();
+}
+
+class _DiceTimerPageState extends State<DiceTimerPage> {
+  /// One full turn of the dial, like a kitchen egg timer.
+  static const int _maxMinutes = 60;
+
+  DiceTimerPhase _phase = DiceTimerPhase.setting;
+
+  /// Time on the dial: the wound-up duration while setting, ticking down
+  /// once a second while running.
+  Duration _remaining = Duration.zero;
+
+  /// Wall-clock moment the countdown hits zero; shown under the dial.
+  DateTime? _endAt;
+
+  Timer? _ticker;
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    // Safety net: leaving the page any other way than the ring actions must
+    // not keep the melody playing.
+    AlarmSound.stop();
+    super.dispose();
+  }
+
+  static Future<void> _defaultRingAlert(Task task) async {
+    await AlarmSound.play(melody: 'Classic', volume: 0.8, loop: true);
+    try {
+      await NotificationService.showTaskNotification(
+        'Time is up: ${task.title}',
+        delaySeconds: 0,
+      );
+    } catch (_) {
+      // Notifications are best-effort (no plugin host on desktop/tests).
+    }
+  }
+
+  void _startCountdown() {
+    if (_remaining <= Duration.zero) return;
+    _ticker?.cancel();
+    setState(() {
+      _phase = DiceTimerPhase.running;
+      _endAt = DateTime.now().add(_remaining);
+    });
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) => _tick());
+    LogService.add(
+      'DiceTimerPage._startCountdown',
+      'Started ${_remaining.inSeconds}s for "${widget.task.title}"',
+    );
+  }
+
+  void _tick() {
+    if (!mounted) return;
+    setState(() {
+      _remaining -= const Duration(seconds: 1);
+      if (_remaining <= Duration.zero) {
+        _remaining = Duration.zero;
+        _ring();
+      }
+    });
+  }
+
+  /// Reached zero: stop ticking and start the alert. Not awaited — ringing
+  /// must never block the UI, and both default alert paths swallow errors.
+  void _ring() {
+    _ticker?.cancel();
+    _ticker = null;
+    _phase = DiceTimerPhase.ringing;
+    (widget.onRingAlert ?? _defaultRingAlert)(widget.task);
+    LogService.add(
+        'DiceTimerPage._ring', 'Timer hit zero for "${widget.task.title}"');
+  }
+
+  /// Grabbing the dial pauses a running countdown (and silences a ring) so it
+  /// can be rewound; releasing starts it again.
+  void _onDialDragStart() {
+    _ticker?.cancel();
+    _ticker = null;
+    if (_phase == DiceTimerPhase.ringing) AlarmSound.stop();
+    if (_phase != DiceTimerPhase.setting) {
+      setState(() {
+        _phase = DiceTimerPhase.setting;
+        _endAt = null;
+        // Whole minutes while winding, like the numbers on an egg timer.
+        _remaining = Duration(minutes: (_remaining.inSeconds / 60).ceil());
+      });
+    }
+  }
+
+  void _onDialChanged(Duration value) {
+    setState(() => _remaining = value);
+  }
+
+  void _onDialDragEnd() {
+    if (_remaining > Duration.zero) _startCountdown();
+  }
+
+  void _addTime(Duration extra) {
+    AlarmSound.stop();
+    setState(() => _remaining += extra);
+    _startCountdown();
+  }
+
+  void _finish(VoidCallback callback) {
+    AlarmSound.stop();
+    callback();
+    Navigator.of(context).pop();
+  }
+
+  String _two(int n) => n.toString().padLeft(2, '0');
+
+  String _formatClock(DateTime t) => '${_two(t.hour)}:${_two(t.minute)}';
+
+  String _formatRemaining(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes % 60;
+    final s = d.inSeconds % 60;
+    return h > 0 ? '$h:${_two(m)}:${_two(s)}' : '$m:${_two(s)}';
+  }
+
+  Widget _dialCenter(BuildContext context) {
+    final theme = Theme.of(context);
+    switch (_phase) {
+      case DiceTimerPhase.setting:
+        if (_remaining == Duration.zero) {
+          return Text(
+            'Turn me',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium,
+          );
+        }
+        return Text(
+          '${_remaining.inMinutes} min',
+          style: theme.textTheme.headlineMedium
+              ?.copyWith(fontWeight: FontWeight.bold),
+        );
+      case DiceTimerPhase.running:
+        return Text(
+          _formatRemaining(_remaining),
+          style: theme.textTheme.headlineMedium
+              ?.copyWith(fontWeight: FontWeight.bold),
+        );
+      case DiceTimerPhase.ringing:
+        return Text(
+          "Time's up!",
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleLarge?.copyWith(
+            color: theme.colorScheme.error,
+            fontWeight: FontWeight.bold,
+          ),
+        );
+    }
+  }
+
+  Widget _statusLine(BuildContext context) {
+    final theme = Theme.of(context);
+    switch (_phase) {
+      case DiceTimerPhase.setting:
+        return Text(
+          'Wind the dial, then let go to start the countdown.',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium,
+        );
+      case DiceTimerPhase.running:
+        return Text(
+          'Ends at ${_formatClock(_endAt!)}',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: theme.colorScheme.primary,
+            fontWeight: FontWeight.w600,
+          ),
+        );
+      case DiceTimerPhase.ringing:
+        return Text(
+          'Did you finish this task?',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium,
+        );
+    }
+  }
+
+  Widget _ringActions() {
+    Widget addButton(int minutes) => OutlinedButton(
+          onPressed: () => _addTime(Duration(minutes: minutes)),
+          child: Text('+$minutes min'),
+        );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton.icon(
+          icon: const Icon(Icons.check),
+          label: const Text('Done'),
+          onPressed: () => _finish(widget.onTaskDone),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.tonalIcon(
+          icon: const Icon(Icons.update),
+          label: const Text('Postpone to tomorrow'),
+          onPressed: () => _finish(widget.onTaskPostponed),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            addButton(1),
+            const SizedBox(width: 8),
+            addButton(5),
+            const SizedBox(width: 8),
+            addButton(10),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: buildSubpageAppBar(context, title: 'Dice timer'),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.casino, color: theme.colorScheme.primary),
+                  const SizedBox(width: 8),
+                  Text('The dice picked', style: theme.textTheme.titleSmall),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                widget.task.title,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.headlineSmall
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 24),
+              SizedBox.square(
+                dimension: 280,
+                child: DiceTimerDial(
+                  value: _remaining,
+                  maxMinutes: _maxMinutes,
+                  onDragStart: _onDialDragStart,
+                  onChanged: _onDialChanged,
+                  onDragEnd: _onDialDragEnd,
+                  center: _dialCenter(context),
+                ),
+              ),
+              const SizedBox(height: 24),
+              _statusLine(context),
+              if (_phase == DiceTimerPhase.ringing) ...[
+                const SizedBox(height: 24),
+                _ringActions(),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A rotary egg-timer dial: drag around the face to wind it up. Reports whole
+/// minutes while winding via [onChanged]; [onDragStart] / [onDragEnd] bracket
+/// every grab so the owner can pause and (re)start the countdown.
+class DiceTimerDial extends StatefulWidget {
+  final Duration value;
+  final int maxMinutes;
+  final ValueChanged<Duration> onChanged;
+  final VoidCallback onDragStart;
+  final VoidCallback onDragEnd;
+  final Widget? center;
+
+  const DiceTimerDial({
+    Key? key,
+    required this.value,
+    required this.onChanged,
+    required this.onDragStart,
+    required this.onDragEnd,
+    this.maxMinutes = 60,
+    this.center,
+  }) : super(key: key);
+
+  @override
+  State<DiceTimerDial> createState() => _DiceTimerDialState();
+}
+
+class _DiceTimerDialState extends State<DiceTimerDial> {
+  /// Continuous wound-up minutes during a drag; fractional so slow drags
+  /// accumulate, reported rounded to whole minutes.
+  double _minutes = 0;
+  double? _lastAngle;
+  int? _pointer;
+  Size _size = Size.zero;
+
+  void _handleStart(PointerDownEvent event) {
+    if (_pointer != null) return;
+    _pointer = event.pointer;
+    _minutes = widget.value.inSeconds / 60.0;
+    _lastAngle = dialAngle(_size.center(Offset.zero), event.localPosition);
+    widget.onDragStart();
+  }
+
+  void _handleUpdate(PointerMoveEvent event) {
+    final last = _lastAngle;
+    if (last == null || event.pointer != _pointer) return;
+    final angle = dialAngle(_size.center(Offset.zero), event.localPosition);
+    _lastAngle = angle;
+    final deltaMinutes =
+        dialAngleDelta(last, angle) / (2 * math.pi) * widget.maxMinutes;
+    _minutes = (_minutes + deltaMinutes)
+        .clamp(0.0, widget.maxMinutes.toDouble())
+        .toDouble();
+    widget.onChanged(Duration(minutes: _minutes.round()));
+  }
+
+  void _handleEnd(PointerEvent event) {
+    if (event.pointer != _pointer) return;
+    _pointer = null;
+    _lastAngle = null;
+    widget.onDragEnd();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final dimension = math.min(constraints.maxWidth, constraints.maxHeight);
+        _size = Size.square(dimension);
+        final fraction = (widget.value.inSeconds / 60.0 / widget.maxMinutes)
+            .clamp(0.0, 1.0)
+            .toDouble();
+        // Raw pointer events instead of a pan recognizer: the dial must keep
+        // winding even when an ancestor scrollable would win a (mostly
+        // vertical) drag in the gesture arena.
+        return Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: _handleStart,
+          onPointerMove: _handleUpdate,
+          onPointerUp: _handleEnd,
+          onPointerCancel: _handleEnd,
+          child: CustomPaint(
+            painter: _DialPainter(
+              fraction: fraction,
+              wedgeColor: scheme.primary,
+              faceColor: scheme.surfaceContainerHighest,
+              innerColor: scheme.surface,
+              tickColor: scheme.onSurfaceVariant,
+            ),
+            child: SizedBox.square(
+              dimension: dimension,
+              child: Center(child: widget.center),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DialPainter extends CustomPainter {
+  final double fraction;
+  final Color wedgeColor;
+  final Color faceColor;
+  final Color innerColor;
+  final Color tickColor;
+
+  const _DialPainter({
+    required this.fraction,
+    required this.wedgeColor,
+    required this.faceColor,
+    required this.innerColor,
+    required this.tickColor,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = size.shortestSide / 2;
+
+    canvas.drawCircle(center, radius, Paint()..color = faceColor);
+
+    // Wound-up wedge from 12 o'clock clockwise — the classic egg-timer look.
+    if (fraction > 0) {
+      canvas.drawArc(
+        Rect.fromCircle(center: center, radius: radius - 4),
+        -math.pi / 2,
+        2 * math.pi * fraction,
+        true,
+        Paint()..color = wedgeColor.withAlpha(70),
+      );
+    }
+
+    // Minute ticks, longer every 5 minutes.
+    for (var i = 0; i < 60; i++) {
+      final major = i % 5 == 0;
+      final angle = i / 60 * 2 * math.pi - math.pi / 2;
+      final dir = Offset(math.cos(angle), math.sin(angle));
+      canvas.drawLine(
+        center + dir * (radius - (major ? 16 : 10)),
+        center + dir * (radius - 4),
+        Paint()
+          ..color = tickColor
+          ..strokeWidth = major ? 2.5 : 1.0
+          ..strokeCap = StrokeCap.round,
+      );
+    }
+
+    // Inner disc keeps the center label readable over the wedge.
+    canvas.drawCircle(center, radius * 0.55, Paint()..color = innerColor);
+
+    // Pointer from the inner disc to the rim at the wound position.
+    final pointerAngle = 2 * math.pi * fraction - math.pi / 2;
+    final dir = Offset(math.cos(pointerAngle), math.sin(pointerAngle));
+    canvas.drawLine(
+      center + dir * (radius * 0.55),
+      center + dir * (radius - 6),
+      Paint()
+        ..color = wedgeColor
+        ..strokeWidth = 4
+        ..strokeCap = StrokeCap.round,
+    );
+    canvas.drawCircle(center + dir * (radius - 6), 7, Paint()..color = wedgeColor);
+  }
+
+  @override
+  bool shouldRepaint(_DialPainter oldDelegate) =>
+      oldDelegate.fraction != fraction ||
+      oldDelegate.wedgeColor != wedgeColor ||
+      oldDelegate.faceColor != faceColor ||
+      oldDelegate.innerColor != innerColor ||
+      oldDelegate.tickColor != tickColor;
+}

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math' show Random;
 
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
@@ -23,6 +24,7 @@ import 'calendar_view_page.dart' show ScheduleView;
 import 'changelog_page.dart';
 import 'chronize_page.dart';
 import 'countdown_timer_page.dart';
+import 'dice_timer_page.dart';
 import 'home_scaffold_key.dart';
 import 'startup_times_page.dart';
 import 'deleted_items_page.dart';
@@ -65,6 +67,9 @@ class _HomePageState extends State<HomePage>
   late final TabController _tabController;
   final TextEditingController _controller = TextEditingController();
   final TextEditingController _searchController = TextEditingController();
+
+  /// Picks which of today's tasks the dice timer lands on.
+  final Random _diceRandom = Random();
 
   /// Current search query; when non-empty every tab (and the schedule view)
   /// only shows tasks matching it.
@@ -1107,6 +1112,71 @@ class _HomePageState extends State<HomePage>
       );
   }
 
+  /// Rolls the dice: picks a random open task from today's tab and opens the
+  /// rotary egg-timer page for it.
+  void _rollRandomTaskTimer() {
+    final candidates =
+        _tasksForTab(0, applySearch: false).where((t) => !t.isDone).toList();
+    if (candidates.isEmpty) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('No open tasks for today')),
+        );
+      return;
+    }
+    final task = candidates[_diceRandom.nextInt(candidates.length)];
+    LogService.add(
+        'HomePage._rollRandomTaskTimer', 'Dice picked "${task.title}"');
+    Navigator.of(context)
+        .push(
+          MaterialPageRoute(
+            builder: (_) => DiceTimerPage(
+              task: task,
+              onTaskDone: () => _completeTaskFromDice(task),
+              onTaskPostponed: () => _postponeTaskFromDice(task),
+            ),
+          ),
+        )
+        .then((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  /// The dice timer rang and the user confirmed the task is done.
+  void _completeTaskFromDice(Task task) {
+    if (task.isDone) return;
+    setState(() {
+      task.isDone = true;
+      task.completedAt = DateTime.now();
+    });
+    _trackTaskDoneState(task, false);
+    _saveTasks();
+    LogService.add(
+        'HomePage._completeTaskFromDice', 'Completed "${task.title}"');
+  }
+
+  /// The dice timer rang and the user postponed the task to tomorrow.
+  void _postponeTaskFromDice(Task task) {
+    if (task.recurrenceParentUid != null) {
+      task.recurrenceParentUid = null;
+      task.recurrenceInstanceKey = null;
+    }
+    final oldDueDate = task.dueDate;
+    final newDueDate = _dueDateForTab(1);
+    setState(() {
+      task.dueDate = newDueDate;
+      final now = DateTime.now();
+      task.movedAt = now;
+      task.rescheduledAt = now;
+      _refreshRecurringForTask(task);
+    });
+    _trackTaskMove(task, oldDueDate, newDueDate);
+    _saveTasks();
+    LogService.add('HomePage._postponeTaskFromDice',
+        'Postponed "${task.title}" to tomorrow');
+  }
+
   void _updateSettings() {
     setState(() {});
     _updateHomeWidget();
@@ -1863,6 +1933,11 @@ class _HomePageState extends State<HomePage>
           onChanged: (value) => setState(() => _searchQuery = value),
         ),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.casino),
+            tooltip: 'Roll a random task timer',
+            onPressed: _rollRandomTaskTimer,
+          ),
           IconButton(
             icon: Icon(_scheduleView
                 ? Icons.format_list_bulleted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.93+63
+version: 0.1.94+64
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ other suites are per-feature silos: run the ones whose area you touched.
 | `test/core/` | `flutter test test/core` | Task model + JSON round-trip, `StorageService` persistence/rollover, config persistence, tab bucketing/filtering (`date_utils`), done-task ordering, reorder ranking, deadline normalization, app-boot smoke test, build-gate smoke test |
 | `test/alarms/` | `flutter test test/alarms` | Alarm model, `AlarmStorageService` round-trip, alarm editor (top save), alarm ring page |
 | `test/projects/` | `flutter test test/projects` | Project model, `ProjectService` (seed/rename/reload/corrupt file), Projects page drag-assign, Kanban board page, task-tile project/stage tags |
-| `test/home/` | `flutter test test/home` | Home page UI: search behaviors, drawer layout (Projects under Tools), task-tile description editing |
+| `test/home/` | `flutter test test/home` | Home page UI: search behaviors, drawer layout (Projects under Tools), task-tile description editing, dice random-task timer |
 | `test/tools/` | `flutter test test/tools` | Auxiliary tools: export/import + analytics CSVs, usage-data service, startup-times page, countdown timer model, chronize page |
 
 ## Which suites to run
@@ -25,7 +25,8 @@ Pick suites by what you touched, always including core:
 - `lib/models/alarm.dart`, `lib/services/alarm_*`, `lib/ui/alarm*` → core + **alarms**
 - `lib/models/project.dart`, `lib/services/project_service.dart`,
   `lib/ui/projects_page.dart`, `lib/ui/project_board_page.dart` → core + **projects**
-- `lib/ui/home_page.dart`, `lib/ui/task_tile.dart` → core + **home**
+- `lib/ui/home_page.dart`, `lib/ui/task_tile.dart`, `lib/ui/dice_timer_page.dart`
+  → core + **home**
   (+ **projects** for `task_tile.dart`, which renders project tags)
 - `lib/services/usage_data_service.dart`, `lib/services/startup_time_service.dart`,
   export/import, `lib/ui/startup_times_page.dart`, `lib/ui/chronize_page.dart`,

--- a/test/home/dice_timer_test.dart
+++ b/test/home/dice_timer_test.dart
@@ -1,0 +1,221 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:besttodo/models/task.dart';
+import 'package:besttodo/services/project_service.dart';
+import 'package:besttodo/services/storage_service.dart';
+import 'package:besttodo/ui/dice_timer_page.dart';
+import 'package:besttodo/ui/home_page.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+void main() {
+  setUp(() async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    ProjectService.instance.resetForTest();
+  });
+
+  group('dial math', () {
+    test('dialAngle measures clockwise from 12 o\'clock', () {
+      const center = Offset(100, 100);
+      expect(dialAngle(center, const Offset(100, 0)), closeTo(0, 1e-9));
+      expect(
+          dialAngle(center, const Offset(200, 100)), closeTo(math.pi / 2, 1e-9));
+      expect(dialAngle(center, const Offset(100, 200)), closeTo(math.pi, 1e-9));
+      expect(dialAngle(center, const Offset(0, 100)),
+          closeTo(3 * math.pi / 2, 1e-9));
+    });
+
+    test('dialAngleDelta takes the short way across 12 o\'clock', () {
+      expect(dialAngleDelta(0.1, 2 * math.pi - 0.1), closeTo(-0.2, 1e-9));
+      expect(dialAngleDelta(2 * math.pi - 0.1, 0.1), closeTo(0.2, 1e-9));
+      expect(dialAngleDelta(1.0, 2.0), closeTo(1.0, 1e-9));
+    });
+  });
+
+  group('DiceTimerPage', () {
+    Future<void> pumpDicePage(
+      WidgetTester tester, {
+      required Task task,
+      VoidCallback? onDone,
+      VoidCallback? onPostponed,
+      Future<void> Function(Task)? onRingAlert,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => DiceTimerPage(
+                        task: task,
+                        onTaskDone: onDone ?? () {},
+                        onTaskPostponed: onPostponed ?? () {},
+                        onRingAlert: onRingAlert ?? (_) async {},
+                      ),
+                    ),
+                  ),
+                  child: const Text('open timer'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open timer'));
+      await tester.pumpAndSettle();
+    }
+
+    /// Winds the dial exactly a quarter turn (3 o'clock → 6 o'clock, 15 min)
+    /// and lets go, which starts the countdown.
+    Future<void> windQuarterTurn(WidgetTester tester) async {
+      final center = tester.getCenter(find.byType(DiceTimerDial));
+      final gesture = await tester.startGesture(center + const Offset(100, 0));
+      await tester.pump();
+      await gesture.moveTo(center + const Offset(70.7, 70.7));
+      await tester.pump();
+      await gesture.moveTo(center + const Offset(0, 100));
+      await tester.pump();
+      expect(find.text('15 min'), findsOneWidget);
+      await gesture.up();
+      await tester.pump();
+    }
+
+    testWidgets(
+        'winding and releasing starts the countdown; at zero the ring '
+        'actions appear and Done reports the task', (tester) async {
+      var done = false;
+      var postponed = false;
+      var rang = 0;
+      await pumpDicePage(
+        tester,
+        task: Task(title: 'Wash the dog'),
+        onDone: () => done = true,
+        onPostponed: () => postponed = true,
+        onRingAlert: (_) async => rang++,
+      );
+
+      expect(find.text('Wash the dog'), findsOneWidget);
+      expect(find.text('Turn me'), findsOneWidget);
+
+      await windQuarterTurn(tester);
+
+      // Countdown running: remaining time plus the wall-clock end time.
+      expect(find.text('15:00'), findsOneWidget);
+      expect(find.textContaining('Ends at'), findsOneWidget);
+      expect(find.text('Done'), findsNothing);
+
+      await tester.pump(const Duration(minutes: 15, seconds: 1));
+
+      expect(rang, 1);
+      expect(find.text("Time's up!"), findsOneWidget);
+      expect(find.text('Postpone to tomorrow'), findsOneWidget);
+      expect(find.text('+5 min'), findsOneWidget);
+
+      await tester.ensureVisible(find.text('Done'));
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+
+      expect(done, isTrue);
+      expect(postponed, isFalse);
+      expect(find.byType(DiceTimerPage), findsNothing);
+    });
+
+    testWidgets('+5 min restarts the countdown and Postpone reports the task',
+        (tester) async {
+      var done = false;
+      var postponed = false;
+      var rang = 0;
+      await pumpDicePage(
+        tester,
+        task: Task(title: 'Water plants'),
+        onDone: () => done = true,
+        onPostponed: () => postponed = true,
+        onRingAlert: (_) async => rang++,
+      );
+
+      await windQuarterTurn(tester);
+      await tester.pump(const Duration(minutes: 15, seconds: 1));
+      expect(rang, 1);
+
+      await tester.ensureVisible(find.text('+5 min'));
+      await tester.tap(find.text('+5 min'));
+      await tester.pump();
+
+      // Running again for another 5 minutes; ring actions are gone.
+      expect(find.text('5:00'), findsOneWidget);
+      expect(find.textContaining('Ends at'), findsOneWidget);
+      expect(find.text('Done'), findsNothing);
+
+      await tester.pump(const Duration(minutes: 5, seconds: 1));
+      expect(rang, 2);
+
+      await tester.ensureVisible(find.text('Postpone to tomorrow'));
+      await tester.tap(find.text('Postpone to tomorrow'));
+      await tester.pumpAndSettle();
+
+      expect(postponed, isTrue);
+      expect(done, isFalse);
+      expect(find.byType(DiceTimerPage), findsNothing);
+    });
+  });
+
+  group('home page dice icon', () {
+    Future<void> pumpHome(WidgetTester tester, List<Task> tasks) async {
+      // All real file I/O (pre-saving tasks, HomePage's initState loads) must
+      // run on the real event loop via runAsync, not the fake-async test zone.
+      await tester.runAsync(() => StorageService().saveTaskList(tasks));
+      await tester.pumpWidget(const MaterialApp(home: HomePage()));
+      final marker = find.text(tasks.first.title);
+      for (var i = 0; i < 300 && marker.evaluate().isEmpty; i++) {
+        await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 5)));
+        await tester.pump();
+      }
+      await tester.pumpAndSettle();
+      expect(marker, findsOneWidget, reason: 'HomePage never loaded the tasks');
+    }
+
+    testWidgets('rolls today\'s only open task and opens the dice timer',
+        (tester) async {
+      await pumpHome(
+        tester,
+        [Task(title: 'Feed the zebra', dueDate: DateTime.now())],
+      );
+
+      await tester.tap(find.byTooltip('Roll a random task timer'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DiceTimerPage), findsOneWidget);
+      expect(find.text('Feed the zebra'), findsOneWidget);
+      expect(find.text('Turn me'), findsOneWidget);
+    });
+
+    testWidgets('shows a message when today has no open tasks',
+        (tester) async {
+      await pumpHome(
+        tester,
+        [Task(title: 'Already handled', dueDate: DateTime.now(), isDone: true)],
+      );
+
+      await tester.tap(find.byTooltip('Roll a random task timer'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.text('No open tasks for today'), findsOneWidget);
+      expect(find.byType(DiceTimerPage), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Adds a new "dice timer" feature that picks a random open task from today and opens a rotary egg-timer interface for time-boxing work.

## Summary
Introduces `DiceTimerPage` with a custom `DiceTimerDial` widget — a rotary egg-timer dial (60-minute full turn) that users wind by dragging to set a duration, then release to start a countdown. When the timer reaches zero, an alarm rings and the user can mark the task done, postpone it to tomorrow, or add extra time. A new dice icon button in the home page app bar triggers the random task selection.

## Key changes

- **New `lib/ui/dice_timer_page.dart`** (504 lines):
  - `DiceTimerPage`: main page showing the rolled task, the dial, and countdown/ring UI
  - `DiceTimerDial`: custom rotary dial widget with raw pointer event handling (not a pan recognizer, to avoid gesture arena conflicts with ancestor scrollables)
  - `_DialPainter`: renders the dial face, wedge, minute ticks, pointer, and inner disc
  - Helper functions `dialAngle()` and `dialAngleDelta()` for continuous rotation math across the 12 o'clock boundary
  - Three-phase state machine: `setting` (winding), `running` (countdown), `ringing` (alarm + actions)
  - Countdown uses a 1-second ticker (not wall-clock-anchored, enabling test fake-pumping)
  - Ring actions: Done, Postpone to tomorrow, +1/+5/+10 min buttons

- **Updated `lib/ui/home_page.dart`**:
  - Added `_diceRandom` field for task selection
  - New `_rollRandomTaskTimer()` method: picks a random open task from today's tab (ignoring search), shows snackbar if none available, pushes `DiceTimerPage`
  - `_completeTaskFromDice()` and `_postponeTaskFromDice()` callbacks to handle ring actions
  - New dice icon button in the app bar (right of search field) with tooltip "Roll a random task timer"

- **New comprehensive test suite** (`test/home/dice_timer_test.dart`, 221 lines):
  - Dial math tests: `dialAngle()` and `dialAngleDelta()` correctness
  - `DiceTimerPage` integration tests: winding, countdown, ring, Done/Postpone/+time actions
  - Home page dice icon tests: random selection, snackbar when no tasks, navigation

- **Documentation updates**:
  - `SPEC.md`: detailed spec for the dice timer feature (0.1.94)
  - `CHANGELOG.md`: user-facing entry for 0.1.94
  - `test/README.md`: updated test suite map
  - `pubspec.yaml`: version bump to 0.1.94+64

## Implementation notes

- **Pointer handling**: Uses raw `Listener` with `onPointerDown/Move/Up/Cancel` instead of a pan recognizer, because ancestor scrollables would win mostly-vertical drags in the gesture arena. The dial must remain responsive even when nested in a scrollable.
- **Continuous rotation**: `dialAngle()` and `dialAngleDelta()` handle the 12 o'clock wraparound, keeping drags smooth when the finger crosses the boundary.
- **Whole-minute snapping**: While winding, the dial reports rounded whole minutes (like a physical egg timer). During countdown, it ticks down by 1-second increments.
- **Test-friendly countdown**: The ticker is duration-based (not wall-clock-anchored), so tests can fake-pump time forward without real delays.
- **Ring alert**: Plays the alarm melody and posts a notification; both are best-effort (no plugin host on desktop/tests). The `onRingAlert` callback is overridable for testing.

https://claude.ai/code/session_01P7whxkboq17r2iXBuviZmS