### PR TITLE
Add platform-aware dragging and dev project seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.91] - 2026-07-07
+- projects: dragging tasks onto projects (and cards between Kanban columns) now works with a plain mouse drag on desktop and in a desktop browser (e.g. Chrome on a laptop) — no long-press needed; touch devices keep the long-press drag so scrolling still works, and the hint text on the Projects page matches the input mode
+- dev builds: the Projects tool comes prepopulated — nine of the dev-seeded future tasks are spread across the three seed projects, one per Kanban column each, so the project cards and boards have data to drag around right away (also on desktop/web); manual assignments are never reshuffled
+
 ## [0.1.90] - 2026-07-07
 - projects: name and description are editable (pencil icon on the project board) and persist across restarts (`projects.json`); renames update everywhere a project is shown
 - projects: moved into the Tools menu (Tools → Projects)

--- a/SPEC.md
+++ b/SPEC.md
@@ -219,7 +219,11 @@ the "due today or overdue" list text (or "Well done! No more tasks for today!"),
 percent, and a color (green all done / orange exactly 4 left / red ≥5 left).
 
 **First-run seeds:** 3 today-tasks + 1 future task; dev builds additionally seed 20 future
-tasks, 20 deleted tasks, and 14 days of stats (marker strings prevent re-seeding).
+tasks, 20 deleted tasks, and 14 days of stats (marker strings prevent re-seeding). Dev
+builds also spread 9 of the seeded future tasks across the three seed projects (one task
+per Kanban column in each project) so the Projects tool opens populated — including on
+desktop/web where storage may not persist; skipped as soon as any seeded task carries a
+`projectId`, so manual (re)assignments survive reloads.
 
 ### 4.4 Settings (all persisted in `settings.json` via `Config`)
 
@@ -484,10 +488,15 @@ bottom pane (flex 2) shows the projects. **Projects persist** via `ProjectServic
 (singleton, `ValueNotifier<List<Project>>`, `projects.json` in app documents dir, seeded
 with `Project.placeholders` "Project 1–3" on first run; corrupt/missing file keeps the
 in-memory seeds). `Project = {id, name, description}` (immutable, `copyWith`); ids are
-stable — tasks reference `projectId`, so renames propagate everywhere. Long-press-drag a
+stable — tasks reference `projectId`, so renames propagate everywhere. Drag a
 task onto a project card to assign it (sets `task.projectId`, resets `kanbanStatus` to
 todo, snackbar confirms; assignment persists via the task's own JSON through `onChanged`
 → `_saveTasks`). Cards show name, one-line description (if any) and live task count.
+Drag sources are `AdaptiveDraggable` (`lib/ui/adaptive_draggable.dart`): long-press-drag
+on touch platforms (Android/iOS incl. mobile web, so drags don't fight list scrolling),
+immediate mouse drag on desktop and desktop web (e.g. Chrome on a laptop; decided via
+`defaultTargetPlatform`, which reflects the underlying OS on web). The hint text above
+the task pane adapts to the input mode.
 
 **Tags on task tiles (0.1.90):** an assigned task shows two small
 `secondaryContainer`-tinted pills under its title on every home tile — the project name
@@ -499,7 +508,8 @@ tool.
 
 **Board** (`ProjectBoardPage`): three equal-width Kanban columns — To-Do (blue
 0xFF90CAF9), Ongoing (orange 0xFFFFCC80), Closed (green 0xFFA5D6A7) — each a `DragTarget`
-with count in the header; long-press-drag cards between columns to change `kanbanStatus`,
+with count in the header; drag cards between columns (same `AdaptiveDraggable`
+long-press-on-touch / immediate-on-mouse behavior) to change `kanbanStatus`,
 tap a card for `TaskDetailPage`, the × on a card unassigns it (clears `projectId`, resets
 stage). **Edit (0.1.90):** pencil action in the app bar opens a name+description dialog;
 Save upserts through `ProjectService` (empty name keeps the old one, description may be
@@ -550,8 +560,10 @@ import round-trip + legacy import, storage rollover, config persistence, alarm m
 storage round-trip, 18:00 deadline normalization, done-task ordering, reorder ranking,
 dev date-advance sweep, home filtering, tile description editing, intro smoke. Projects &
 search (0.1.90): project model + `ProjectService` persistence (seed/rename/reload/corrupt
-file), projects page (drag-assign, renamed-projects-from-disk), board page (column
-grouping, drag between columns, unassign, edit dialog save/cancel/empty-name), task-tile
+file), projects page (drag-assign incl. desktop mouse drag, renamed-projects-from-disk,
+platform-dependent hint), board page (column grouping, drag between columns incl. desktop
+mouse drag, unassign, edit dialog save/cancel/empty-name), dev project seed (spread across
+projects/columns, no reshuffle of existing assignments), task-tile
 project/stage tags (incl. live rename + unknown-id fallback), home search (title/
 description/label/project-name matching, case-insensitivity, clear button, empty state),
 drawer placement of Projects under Tools, alarm-editor top save action. Widget tests that

--- a/lib/ui/adaptive_draggable.dart
+++ b/lib/ui/adaptive_draggable.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Drag source that adapts to how the platform is driven. Touch platforms
+/// (Android/iOS, including mobile browsers) keep [LongPressDraggable] so a
+/// drag doesn't compete with list scrolling; mouse-driven platforms (desktop
+/// builds and desktop web, e.g. Chrome on a laptop) get an immediate
+/// [Draggable] because click-and-hold before dragging is unnatural with a
+/// mouse.
+class AdaptiveDraggable<T extends Object> extends StatelessWidget {
+  final T data;
+  final Widget feedback;
+  final Widget? childWhenDragging;
+  final Widget child;
+
+  const AdaptiveDraggable({
+    Key? key,
+    required this.data,
+    required this.feedback,
+    this.childWhenDragging,
+    required this.child,
+  }) : super(key: key);
+
+  /// Whether the current platform is primarily touch-driven. On web,
+  /// [defaultTargetPlatform] reflects the underlying OS, so Chrome on a
+  /// laptop counts as mouse-driven while Chrome on a phone stays touch.
+  static bool get isTouchPlatform {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+      case TargetPlatform.fuchsia:
+        return true;
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isTouchPlatform) {
+      return LongPressDraggable<T>(
+        data: data,
+        feedback: feedback,
+        childWhenDragging: childWhenDragging,
+        child: child,
+      );
+    }
+    return Draggable<T>(
+      data: data,
+      feedback: feedback,
+      childWhenDragging: childWhenDragging,
+      child: child,
+    );
+  }
+}

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -269,6 +269,21 @@ class _HomePageState extends State<HomePage>
     return seeded;
   }
 
+  /// Spreads the dev-seeded future tasks across the seed projects (one task
+  /// per Kanban column in each project) so dev builds — including desktop
+  /// and web, where the Projects tool is exercised with a mouse — open with
+  /// populated project cards and boards. Only runs while none of the seeded
+  /// tasks carries a project yet, so manual (re)assignments survive reloads.
+  void _applyDevProjectSeed() {
+    assignDevProjectSeed(
+      _tasks
+          .where((t) =>
+              t.deletedAt == null && t.description == _devFutureTaskMarker)
+          .toList(),
+      ProjectService.instance.list,
+    );
+  }
+
   Map<String, DailyTaskStats> _buildDevDailyStatsSeed(DateTime referenceDate) {
     final seeds = <String, DailyTaskStats>{};
     final dayStart = DateTime(
@@ -396,6 +411,11 @@ class _HomePageState extends State<HomePage>
           !_tasks.any((t) => t.description == _devFutureTaskMarker)) {
         _tasks.addAll(_buildDevFutureTasksSeed(_currentDate));
       }
+    }
+    // Prepopulate the Projects tool in dev builds so the cards/boards have
+    // data to drag around right away.
+    if (Config.isDev) {
+      _applyDevProjectSeed();
     }
     _refreshAllRecurringTasks();
     if (loadedDeleted.isNotEmpty) {

--- a/lib/ui/project_board_page.dart
+++ b/lib/ui/project_board_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/project.dart';
 import '../models/task.dart';
 import '../services/project_service.dart';
+import 'adaptive_draggable.dart';
 import 'subpage_app_bar.dart';
 import 'task_detail_page.dart';
 
@@ -217,7 +218,7 @@ class _ProjectBoardPageState extends State<ProjectBoardPage> {
       ),
     );
 
-    return LongPressDraggable<Task>(
+    return AdaptiveDraggable<Task>(
       data: task,
       feedback: Material(
         elevation: 4,

--- a/lib/ui/projects_page.dart
+++ b/lib/ui/projects_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/project.dart';
 import '../models/task.dart';
 import '../services/project_service.dart';
+import 'adaptive_draggable.dart';
 import 'project_board_page.dart';
 import 'subpage_app_bar.dart';
 
@@ -98,11 +99,13 @@ class _ProjectsPageState extends State<ProjectsPage> {
             style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
           ),
         ),
-        const Padding(
-          padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
           child: Text(
-            'Long-press a task and drag it onto a project below.',
-            style: TextStyle(fontSize: 12, color: Colors.black54),
+            AdaptiveDraggable.isTouchPlatform
+                ? 'Long-press a task and drag it onto a project below.'
+                : 'Drag a task onto a project below.',
+            style: const TextStyle(fontSize: 12, color: Colors.black54),
           ),
         ),
         Expanded(
@@ -138,7 +141,7 @@ class _ProjectsPageState extends State<ProjectsPage> {
       ),
     );
 
-    return LongPressDraggable<Task>(
+    return AdaptiveDraggable<Task>(
       data: task,
       feedback: Material(
         elevation: 4,

--- a/lib/utils/task_utils.dart
+++ b/lib/utils/task_utils.dart
@@ -1,3 +1,4 @@
+import '../models/project.dart';
 import '../models/task.dart';
 
 /// Default deadline time of day for tasks, expressed in minutes since
@@ -13,6 +14,29 @@ void sortTasks(List<Task> list) {
     return (a.listRanking ?? 1 << 31)
         .compareTo(b.listRanking ?? 1 << 31);
   });
+}
+
+/// Dev-only seed helper: spreads [seedTasks] across [projects] — one task per
+/// Kanban column (To-Do/Ongoing/Closed) in each project — so the Projects
+/// tool opens with populated cards and boards in dev builds. Assignment goes
+/// round-robin over the projects, filling every project's To-Do column
+/// first, then Ongoing, then Closed; tasks beyond `projects × 3` are left
+/// untouched. No-op when either list is empty or when any seed task already
+/// carries a project, so manual (re)assignments survive reloads.
+void assignDevProjectSeed(List<Task> seedTasks, List<Project> projects) {
+  if (seedTasks.isEmpty || projects.isEmpty) return;
+  if (seedTasks.any((t) => t.projectId != null)) return;
+  const stages = <String>[
+    Task.kanbanTodo,
+    Task.kanbanOngoing,
+    Task.kanbanClosed,
+  ];
+  final slots = projects.length * stages.length;
+  final limit = seedTasks.length < slots ? seedTasks.length : slots;
+  for (var i = 0; i < limit; i++) {
+    seedTasks[i].projectId = projects[i % projects.length].id;
+    seedTasks[i].kanbanStatus = stages[(i ~/ projects.length) % stages.length];
+  }
 }
 
 /// Ensures every task's deadline time defaults to 18:00. When several tasks

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.90+60
+version: 0.1.91+61
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/dev_project_seed_test.dart
+++ b/test/dev_project_seed_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:besttodo/models/project.dart';
+import 'package:besttodo/models/task.dart';
+import 'package:besttodo/utils/task_utils.dart';
+
+void main() {
+  List<Task> makeTasks(int count) =>
+      List.generate(count, (i) => Task(title: 'Seed $i'));
+
+  test('spreads one task per Kanban column into each project', () {
+    final tasks = makeTasks(20);
+
+    assignDevProjectSeed(tasks, Project.placeholders);
+
+    final assigned = tasks.where((t) => t.projectId != null).toList();
+    expect(assigned, hasLength(9));
+    for (final project in Project.placeholders) {
+      final stages = assigned
+          .where((t) => t.projectId == project.id)
+          .map((t) => t.kanbanStatus)
+          .toList();
+      expect(stages, hasLength(3));
+      expect(stages.toSet(),
+          {Task.kanbanTodo, Task.kanbanOngoing, Task.kanbanClosed});
+    }
+    // Tasks beyond the 3×3 slots stay untouched.
+    for (final task in tasks.skip(9)) {
+      expect(task.projectId, isNull);
+      expect(task.kanbanStatus, Task.kanbanTodo);
+    }
+  });
+
+  test('fills every To-Do column first when there are few tasks', () {
+    final tasks = makeTasks(4);
+
+    assignDevProjectSeed(tasks, Project.placeholders);
+
+    expect(tasks[0].projectId, 'project_1');
+    expect(tasks[1].projectId, 'project_2');
+    expect(tasks[2].projectId, 'project_3');
+    for (final task in tasks.take(3)) {
+      expect(task.kanbanStatus, Task.kanbanTodo);
+    }
+    expect(tasks[3].projectId, 'project_1');
+    expect(tasks[3].kanbanStatus, Task.kanbanOngoing);
+  });
+
+  test('does nothing when a seed task already carries a project', () {
+    final tasks = makeTasks(5);
+    tasks[2].projectId = 'project_2';
+    tasks[2].kanbanStatus = Task.kanbanOngoing;
+
+    assignDevProjectSeed(tasks, Project.placeholders);
+
+    // Manual assignments survive: nothing was added or reshuffled.
+    final assigned = tasks.where((t) => t.projectId != null).toList();
+    expect(assigned, hasLength(1));
+    expect(tasks[2].projectId, 'project_2');
+    expect(tasks[2].kanbanStatus, Task.kanbanOngoing);
+  });
+
+  test('is a no-op for empty task or project lists', () {
+    final tasks = makeTasks(3);
+    assignDevProjectSeed(tasks, const []);
+    expect(tasks.every((t) => t.projectId == null), isTrue);
+
+    // Must not throw on an empty task list.
+    assignDevProjectSeed(<Task>[], Project.placeholders);
+  });
+}

--- a/test/home_drawer_tools_projects_test.dart
+++ b/test/home_drawer_tools_projects_test.dart
@@ -51,6 +51,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('All Tasks'), findsOneWidget);
-    expect(find.text('Project 1'), findsOneWidget);
+    // At least the project card; dev-seeded tasks may show it as a chip too.
+    expect(find.text('Project 1'), findsWidgets);
   });
 }

--- a/test/project_board_page_test.dart
+++ b/test/project_board_page_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -85,6 +86,28 @@ void main() {
     expect(changed, 1);
     expect(find.text('To-Do (0)'), findsOneWidget);
     expect(find.text('Ongoing (1)'), findsOneWidget);
+  });
+
+  testWidgets('on desktop a plain mouse drag moves a card between columns',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final task = Task(title: 'Plan', projectId: 'project_1');
+    var changed = 0;
+    await pumpBoard(tester, [task], onChanged: () => changed++);
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('Plan')),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump(const Duration(milliseconds: 20));
+    await gesture.moveTo(tester.getCenter(find.text('Ongoing (0)')));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(task.kanbanStatus, Task.kanbanOngoing);
+    expect(changed, 1);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets('the close button removes a task from the project',

--- a/test/projects_page_test.dart
+++ b/test/projects_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -91,6 +92,42 @@ void main() {
 
     // Drain the snackbar's auto-dismiss timer so the test ends clean.
     await tester.pumpAndSettle(const Duration(seconds: 3));
+  });
+
+  testWidgets(
+      'on desktop a plain mouse drag (no long-press) assigns the task',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final task = Task(title: 'Alpha');
+    var changed = 0;
+    await pumpPage(tester, [task], onChanged: () => changed++);
+
+    // Mouse users get the immediate Draggable and the shorter hint.
+    expect(find.text('Drag a task onto a project below.'), findsOneWidget);
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('Alpha')),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump(const Duration(milliseconds: 20));
+    await gesture.moveTo(tester.getCenter(find.text('Project 1')));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(task.projectId, 'project_1');
+    expect(changed, 1);
+
+    // Drain the snackbar's auto-dismiss timer so the test ends clean.
+    await tester.pumpAndSettle(const Duration(seconds: 3));
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('touch platforms keep the long-press hint', (tester) async {
+    await pumpPage(tester, [Task(title: 'Alpha')]);
+
+    expect(find.text('Long-press a task and drag it onto a project below.'),
+        findsOneWidget);
   });
 
   testWidgets('an assigned task shows its project as a chip in the task pane',


### PR DESCRIPTION
## Summary
Introduces platform-aware drag interactions for task assignment and Kanban board operations, plus dev-build project seeding to prepopulate the Projects tool with sample data.

## Key Changes

- **AdaptiveDraggable widget** (`lib/ui/adaptive_draggable.dart`): New reusable component that switches between `LongPressDraggable` on touch platforms (Android/iOS/mobile web) and immediate `Draggable` on desktop/desktop web. Platform detection uses `defaultTargetPlatform`, which correctly reflects the underlying OS even on web.

- **Projects page drag interactions**: Replaced `LongPressDraggable` with `AdaptiveDraggable` for task-to-project assignment. Updated hint text to adapt: "Long-press a task and drag it..." on touch, "Drag a task onto a project below." on desktop.

- **Project board drag interactions**: Replaced `LongPressDraggable` with `AdaptiveDraggable` for card-between-columns moves, maintaining the same platform-aware behavior.

- **Dev project seeding** (`assignDevProjectSeed` in `lib/utils/task_utils.dart`): New utility that spreads seeded future tasks across the three placeholder projects (one task per Kanban column per project, 9 tasks total). Round-robin assignment fills all To-Do columns first, then Ongoing, then Closed. No-op if any seeded task already carries a `projectId`, preserving manual assignments across reloads.

- **Home page integration**: Calls `_applyDevProjectSeed()` during initialization in dev builds to prepopulate project cards and boards immediately, improving the dev experience on desktop/web where storage may not persist.

- **Test coverage**: Added comprehensive test suite (`test/dev_project_seed_test.dart`) covering round-robin distribution, partial task lists, existing assignments, and edge cases. Added widget tests for desktop mouse drag on both Projects and Board pages, plus platform-dependent hint text verification.

- **Documentation**: Updated SPEC.md and CHANGELOG.md to reflect the new dragging behavior and dev seeding feature.

## Notable Details

- The `AdaptiveDraggable.isTouchPlatform` static getter centralizes platform detection logic, making it reusable across the UI.
- Dev seeding is idempotent: once any seeded task is manually assigned, the entire seed operation becomes a no-op, so user edits survive reloads.
- Version bumped to 0.1.91+61 per the bump-sync-build workflow.

https://claude.ai/code/session_01Wa6g4EGxX32XnW9NntsBso