### PR TITLE
Wishlist on Future tab ("wish" tag) + one-time Todo.md backlog import ("old" tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.100] - 2026-07-09
+- Wishlist items now also show up at the bottom of the Future tab, tagged "wish" — read-only there, tap one to open the Wishlist tool; the home search filters them like tasks, and they stay out of your real task list
+- One-time import: the still-open ideas from the old Todo.md backlog are added to your wishlist tagged "old"; items you already have (same title) are skipped, nothing existing is changed or removed, and re-deleting an imported item sticks
+
 ## [0.1.99] - 2026-07-09
 - Test Results moved into the Tools menu; it now pulls the latest CI test results from the dev build online (the report bundled in your APK is used as an offline fallback) and clearly shows the app version you are running versus the version the tests were run against.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -614,7 +614,34 @@ cleared); the app-bar title and a hint-colored description line under it update 
 Original board written pre-0.1.58, merged at 0.1.89; still uses deprecated
 `onWillAccept`/`onAccept` and some hardcoded `Colors.black45`-style hints.
 
-### 10.6 The rest
+### 10.6 Wishlist (0.1.94–0.1.95, Future-tab mirror + Todo.md import 0.1.100)
+Tools → Wishlist (`lib/ui/wishlist_page.dart`): a separate task-shaped list for ideas,
+persisted as `wishlist.json` (list of `Task` JSON; only title/description/label are
+used). Add/edit dialog (title, description, labels/tags text field with quick
+`priority-low/medium/high` buttons that replace any existing priority label), per-item
+and export-all JSON export (`{export_version: 1, exported_at, wishlist_items: [...]}`),
+delete per item. Labels are split on commas/whitespace and rendered as chips.
+
+**Future-tab mirror (0.1.100):** HomePage loads the wishlist in `_loadTasks` (and
+reloads after returning from any tool) into `_wishlistItems`, which is kept strictly
+separate from `_tasks` so wish items can never leak into `tasks.json`, the schedule
+view, stats or reordering. The Future tab renders them after the real future tasks as
+read-only cards tagged with a "wish" chip (plus the item's own label chips); the home
+search filters them like tasks; tapping one opens the Wishlist tool.
+`_reorderTask`'s range guards make drags that start on or cross into the wish region
+no-ops.
+
+**One-time Todo.md import (0.1.100):** `lib/services/wishlist_migration.dart` bakes in
+the still-open ideas from the repo's historical `Todo.md` ("After MVP → TODO" + "Later"
+sections, verbatim; 63 items, DONE sections excluded).
+`StorageService.loadWishlist()` merges them once into the wishlist, each labelled
+`old`, deduplicating against existing items by normalized title (lowercased,
+whitespace-collapsed) and never modifying or removing existing entries. The run is
+guarded by a `wishlist_todo_import_v1.txt` flag file so later deletions of imported
+items stick, and the import is skipped entirely (no flag, no write) when an existing
+`wishlist.json` fails to parse, so a corrupt-but-recoverable file is never overwritten.
+
+### 10.7 The rest
 **App Logs**: in-memory `LogService` (ValueNotifier, self-trims >24 h, NOT persisted).
 **Startup Times**: summary card (typical/last/fastest/slowest, hero median), fl_chart line
 chart of the last 30 launches (y-axis fits data, shaded band >1 s, date labels, tap

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import '../models/countdown_timer.dart';
 import '../models/daily_task_stats.dart';
 import '../models/task.dart';
+import 'wishlist_migration.dart';
 
 class TaskImportBundle {
   final List<Task> tasks;
@@ -28,6 +29,12 @@ class StorageService {
   static const _dateFileName = 'last_opened.txt';
   static const _countdownFileName = 'countdown_timers.json';
   static const _wishlistFileName = 'wishlist.json';
+
+  /// Marker written after the one-time Todo.md → wishlist import so it never
+  /// re-adds items the user has since deleted. Public so tests can pre-create
+  /// it to opt out of the import.
+  static const String wishlistImportFlagFileName =
+      'wishlist_todo_import_v1.txt';
   static const _maxDeletedTasks = 100;
   static const int exportVersion = 2;
 
@@ -166,20 +173,60 @@ class StorageService {
   }
 
   Future<List<Task>> loadWishlist() async {
+    List<Task> items;
     try {
       final file = await _getWishlistFile();
-      if (!await file.exists()) {
-        return <Task>[];
+      if (await file.exists()) {
+        final contents = await file.readAsString();
+        final List<dynamic> data = jsonDecode(contents);
+        items = data
+            .map((e) => Task.fromJson(e as Map<String, dynamic>))
+            .toList();
+        _ensureUniqueIds(items);
+      } else {
+        items = <Task>[];
       }
-      final contents = await file.readAsString();
-      final List<dynamic> data = jsonDecode(contents);
-      final items = data
-          .map((e) => Task.fromJson(e as Map<String, dynamic>))
-          .toList();
-      _ensureUniqueIds(items);
-      return items;
     } catch (_) {
+      // An existing wishlist that fails to load must never be overwritten by
+      // the legacy import below, so bail out without touching the file.
       return <Task>[];
+    }
+    await _maybeImportLegacyTodoItems(items);
+    return items;
+  }
+
+  /// One-time merge of the historical Todo.md backlog into the wishlist
+  /// (labelled [legacyTodoImportLabel]). Existing items are never modified or
+  /// removed; entries whose normalized title is already present are skipped.
+  /// Guarded by [wishlistImportFlagFileName] so user deletions stick.
+  Future<void> _maybeImportLegacyTodoItems(List<Task> items) async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final flag = File('${dir.path}/$wishlistImportFlagFileName');
+      if (await flag.exists()) return;
+
+      final existingTitles =
+          items.map((t) => normalizeWishlistTitle(t.title)).toSet();
+      final added = <Task>[];
+      for (final legacy in legacyTodoWishlistItems) {
+        if (!existingTitles.add(normalizeWishlistTitle(legacy.title))) {
+          continue;
+        }
+        added.add(Task(
+          title: legacy.title,
+          description: legacy.description,
+          label: legacyTodoImportLabel,
+          createdAt: DateTime.now(),
+        ));
+      }
+      if (added.isNotEmpty) {
+        items.addAll(added);
+        await saveWishlist(items);
+      }
+      await flag.writeAsString(DateTime.now().toIso8601String(), flush: true);
+    } catch (_) {
+      // No documents dir (web/tests) or write failure: keep working with the
+      // in-memory list; the import will be retried on a later load.
     }
   }
 

--- a/lib/services/wishlist_migration.dart
+++ b/lib/services/wishlist_migration.dart
@@ -1,0 +1,119 @@
+/// One-time import of the historical `Todo.md` backlog into the wishlist.
+///
+/// The repo's `Todo.md` predates the Wishlist tool; its still-open ideas
+/// (the "After MVP → TODO" and "Later" sections, verbatim including typos)
+/// are baked in here so every install can migrate them into
+/// `wishlist.json` exactly once. Items already finished (the DONE
+/// sections) are intentionally not imported.
+class LegacyTodoItem {
+  final String title;
+  final String description;
+
+  const LegacyTodoItem(this.title, [this.description = '']);
+}
+
+/// Label given to every imported item so old backlog entries are
+/// recognizable in the wishlist.
+const String legacyTodoImportLabel = 'old';
+
+/// Lowercases and collapses whitespace so "Calendar view" and
+/// "calendar  view" count as the same wishlist entry when deduplicating.
+String normalizeWishlistTitle(String title) =>
+    title.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+
+const List<LegacyTodoItem> legacyTodoWishlistItems = <LegacyTodoItem>[
+  // Todo.md — "After MVP" → TODO
+  LegacyTodoItem(
+      'add a setting to enable or disable people you are sending it to, so you dont just have to delete there number'),
+  LegacyTodoItem('full testing suite, only merge if all test are complete'),
+  LegacyTodoItem('calendar view'),
+  LegacyTodoItem(
+      'build on github: have a manual action to build the apk on github so i can work remotely'),
+  LegacyTodoItem('ios mode'),
+  LegacyTodoItem(
+      'receiving sms to send you back the task list, so if my friend sends me : "tasks" it automatically sends back todays tasks'),
+  LegacyTodoItem('send emails'),
+  LegacyTodoItem('send in app to each other'),
+  LegacyTodoItem(
+      'add more settings to controll the days of the week on the swiping motion and different icons and the cancel color etc'),
+  LegacyTodoItem(
+      'search function should also be able to show when you type a date and it should show items from the dates around it as well, it should prioritize the tiltel but also look in the description'),
+  LegacyTodoItem(
+    'have extra function for the countdown timer "when is"',
+    'this will show you the closest round numbers, when they fall and the option to send you a reminder',
+  ),
+  LegacyTodoItem(
+    'add another tool just as a test the "chronize" tool',
+    'it list all the tasks from the task list but on a 24hr calendar view and on the right hand side you have 3 sliders, one for the hour, day and month, so you can scroll the list for fine detail, hour roller for going 3 days in one top to bottom scroll, 15 days in a top to bottom scroll and 12 months in a top to bottom scroll.',
+  ),
+  LegacyTodoItem('add a sync function with google calendars'),
+  LegacyTodoItem(
+      'add clever filter functions to sort and filter all the timers and events'),
+  LegacyTodoItem('add optional week numbers to the date selectors everythere'),
+  LegacyTodoItem(
+      'Completed task behavior: Auto-hide completed tasks after X time, or show them grouped at bottom.'),
+  LegacyTodoItem(
+      'Auto-delete completed tasks: Optional cleanup rule (e.g., after 7/30 days).'),
+  LegacyTodoItem(
+      'Default due bucket: When creating a task quickly, choose default target list (Today vs Future).'),
+  LegacyTodoItem(
+      'Confirmation toggles: Per-action confirmations: delete, clear completed, move all.'),
+  LegacyTodoItem(
+      'Sort mode per list: Manual only vs by created time / priority / due date.'),
+  LegacyTodoItem('Settings onepager, click on top tabs to scroll down'),
+  LegacyTodoItem('improve integration test with screenshots'),
+  LegacyTodoItem('improve recurring tasks'),
+  LegacyTodoItem('add home to menu'),
+  LegacyTodoItem(
+      'on the start screen, have 3 buttons, populate with example data or start fresh or import previous data'),
+  LegacyTodoItem('1 working automatic test when building or pushing'),
+  LegacyTodoItem('add a simplified mode'),
+  LegacyTodoItem('delete all, select before delete'),
+  LegacyTodoItem(
+      'have a way to sent a notification about that item in 5- 20 or 60 minutes'),
+  LegacyTodoItem(
+      'extra stats, when is the most productive day. When is the most productive time? When is the time where I plan the most? Which day do I postpone the most? All those kinds of variants'),
+  LegacyTodoItem(
+      'add an advanced mode switch in the menu that hides a lot of the settings for the non-advanced users.'),
+  LegacyTodoItem(
+      'settings for green progress bar to be green when 3 or less tasks are left, orange when 4 tasks are left and red when 5 or more tasks are left. to change the colors and the thresholds.'),
+  LegacyTodoItem('Make icons even bigger?'),
+  LegacyTodoItem(
+      'show in daily stats a different color if you have cleared tasks from a future date.'),
+  LegacyTodoItem(
+      'add a demo mode that you can toggle, like an interactive walktrough'),
+  LegacyTodoItem('add a language selection somewhere.'),
+  // Todo.md — "Later"
+  LegacyTodoItem('add logo in banners etc'),
+  LegacyTodoItem('link to google calendar'),
+  LegacyTodoItem('add video to youtube channel'),
+  LegacyTodoItem('add story and vision to about page'),
+  LegacyTodoItem('add to f-droid store if possible'),
+  LegacyTodoItem('add to galaxy store if possible'),
+  LegacyTodoItem('update startup times'),
+  LegacyTodoItem('web version'),
+  LegacyTodoItem('add to apple store (much later)'),
+  LegacyTodoItem(
+      'make header like google mail 2 menus with search in the middle'),
+  LegacyTodoItem('make a menu on the top right with sorting options'),
+  LegacyTodoItem(
+      'make it an option that the menu is always visible on the left but only the icons'),
+  LegacyTodoItem(
+    'add setting pro mode',
+    'easy mode is default and it hides certain settings',
+  ),
+  LegacyTodoItem('filter on labels'),
+  LegacyTodoItem('complete a tab statistics'),
+  LegacyTodoItem('sliver app bar and floating'),
+  LegacyTodoItem('have selectable text everyhere'),
+  LegacyTodoItem('make a tab wishlist'),
+  LegacyTodoItem('bulk edit (also for labels)'),
+  LegacyTodoItem('encrypt the local db'),
+  LegacyTodoItem('add a web version to your own server'),
+  LegacyTodoItem('automatic backup to any cloud service'),
+  LegacyTodoItem('make calendar view'),
+  LegacyTodoItem('ask feedback sanja'),
+  LegacyTodoItem('let user chose a time for the deadline'),
+  LegacyTodoItem('daily notification of tasks due today'),
+  LegacyTodoItem('reports on what you did'),
+];

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -56,6 +56,11 @@ class _HomePageState extends State<HomePage>
   /// filtered into the appropriate lists based on [_currentDate].
   final List<Task> _tasks = [];
   final List<Task> _deletedTasks = [];
+
+  /// Wishlist items (wishlist.json) mirrored at the bottom of the Future tab
+  /// as read-only tiles tagged "wish". They are never part of [_tasks], so
+  /// they cannot leak into tasks.json or the schedule/reorder logic.
+  final List<Task> _wishlistItems = [];
   final Map<String, DailyTaskStats> _dailyStatsByDay = {};
   final StorageService _storageService = StorageService();
 
@@ -396,6 +401,11 @@ class _HomePageState extends State<HomePage>
     final loaded = await _storageService.loadTaskList();
     final loadedDeleted = await _storageService.loadDeletedTaskList();
     final loadedDailyStats = await _storageService.loadDailyTaskStats();
+    // Also runs the one-time Todo.md → wishlist import on first load.
+    final loadedWishlist = await _storageService.loadWishlist();
+    _wishlistItems
+      ..clear()
+      ..addAll(loadedWishlist);
     if (loaded.isEmpty) {
       _tasks.addAll(
         Config.initialTasks.map((t) => Task(
@@ -756,6 +766,19 @@ class _HomePageState extends State<HomePage>
       // Tools like Projects mutate tasks in place; refresh the lists when
       // coming back.
       if (mounted) setState(() {});
+      // The Wishlist tool persists straight to wishlist.json, so the Future
+      // tab's wish tiles are reloaded from disk.
+      _reloadWishlist();
+    });
+  }
+
+  Future<void> _reloadWishlist() async {
+    final items = await _storageService.loadWishlist();
+    if (!mounted) return;
+    setState(() {
+      _wishlistItems
+        ..clear()
+        ..addAll(items);
     });
   }
 
@@ -1761,8 +1784,23 @@ class _HomePageState extends State<HomePage>
     );
   }
 
+  /// Wishlist items shown on the Future tab, narrowed by the active search
+  /// query like regular tasks.
+  List<Task> _visibleWishlistItems() {
+    final query = _searchQuery.trim().toLowerCase();
+    if (query.isEmpty) return _wishlistItems;
+    return _wishlistItems
+        .where((item) => _matchesSearch(item, query))
+        .toList();
+  }
+
   Widget _buildTaskList(int pageIndex) {
     final tasks = _tasksForTab(pageIndex);
+    // Wish tiles render after the real tasks; _reorderTask ignores drags that
+    // start in or end past the task range, so they stay pinned at the bottom.
+    final wishes = pageIndex == _futureTabIndex
+        ? _visibleWishlistItems()
+        : const <Task>[];
     return Column(
       children: [
         _buildAddTaskRow(),
@@ -1770,15 +1808,61 @@ class _HomePageState extends State<HomePage>
           child: tasks.isEmpty && pageIndex == 0
               ? const Center(child: Text('No tasks for today'))
               : ReorderableListView.builder(
-                  itemCount: tasks.length,
+                  itemCount: tasks.length + wishes.length,
                   onReorder: (oldIndex, newIndex) =>
                       _reorderTask(pageIndex, oldIndex, newIndex),
                   buildDefaultDragHandles: true,
-                  itemBuilder: (context, index) =>
-                      _buildTaskTile(tasks[index], pageIndex, index),
+                  itemBuilder: (context, index) => index < tasks.length
+                      ? _buildTaskTile(tasks[index], pageIndex, index)
+                      : _buildWishTile(wishes[index - tasks.length]),
                 ),
         )
       ],
+    );
+  }
+
+  /// Read-only tile for a wishlist item on the Future tab. Tagged "wish";
+  /// tapping opens the Wishlist tool, where the item can be edited.
+  Widget _buildWishTile(Task item) {
+    final labels = item.label
+        .split(RegExp(r'[,\s]+'))
+        .map((label) => label.trim())
+        .where((label) => label.isNotEmpty)
+        .toList();
+    return Card(
+      key: ValueKey('wish-${item.uid}'),
+      child: ListTile(
+        leading: const Icon(Icons.card_giftcard_outlined),
+        title: Text(item.title),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (item.description.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(item.description),
+            ],
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: [
+                const Chip(
+                  label: Text('wish'),
+                  visualDensity: VisualDensity.compact,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                for (final label in labels)
+                  Chip(
+                    label: Text(label),
+                    visualDensity: VisualDensity.compact,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+              ],
+            ),
+          ],
+        ),
+        onTap: () => _openTool('wishlist'),
+      ),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.99+69
+version: 0.1.100+70
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/README.md
+++ b/test/README.md
@@ -12,8 +12,8 @@ other suites are per-feature silos: run the ones whose area you touched.
 | `test/core/` | `flutter test test/core` | Task model + JSON round-trip, `StorageService` persistence/rollover, config persistence, tab bucketing/filtering (`date_utils`), done-task ordering, reorder ranking, deadline normalization, app-boot smoke test, build-gate smoke test |
 | `test/alarms/` | `flutter test test/alarms` | Alarm model, `AlarmStorageService` round-trip, alarm editor (top save), alarm ring page |
 | `test/projects/` | `flutter test test/projects` | Project model, `ProjectService` (seed/rename/reload/corrupt file), Projects page drag-assign, Kanban board page, task-tile project/stage tags |
-| `test/home/` | `flutter test test/home` | Home page UI: search behaviors, drawer layout (Projects under Tools), task-tile description editing, test-failure red dot on the hamburger/drawer, settings search, dice random-task timer |
-| `test/tools/` | `flutter test test/tools` | Auxiliary tools: export/import + analytics CSVs, usage-data service, startup-times page, countdown timer model, chronize page, CI test report model/parser + Test Results page |
+| `test/home/` | `flutter test test/home` | Home page UI: search behaviors, drawer layout (Projects under Tools), task-tile description editing, test-failure red dot on the hamburger/drawer, settings search, dice random-task timer, wishlist items on the Future tab |
+| `test/tools/` | `flutter test test/tools` | Auxiliary tools: export/import + analytics CSVs, usage-data service, startup-times page, countdown timer model, chronize page, CI test report model/parser + Test Results page, wishlist Todo.md import migration |
 
 ## Which suites to run
 
@@ -32,6 +32,7 @@ Pick suites by what you touched, always including core:
   export/import, `lib/ui/startup_times_page.dart`, `lib/ui/chronize_page.dart`,
   `lib/models/countdown_timer.dart`, `lib/models/test_report.dart`,
   `lib/services/test_report_service.dart`, `lib/ui/test_results_page.dart`,
+  `lib/services/wishlist_migration.dart`, `lib/ui/wishlist_page.dart`,
   `tool/generate_test_report.dart` → core + **tools**
 
 Multiple suites can be passed in one invocation:

--- a/test/home/home_future_wishlist_test.dart
+++ b/test/home/home_future_wishlist_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:besttodo/models/task.dart';
+import 'package:besttodo/services/project_service.dart';
+import 'package:besttodo/services/storage_service.dart';
+import 'package:besttodo/ui/home_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    ProjectService.instance.resetForTest();
+    // Opt out of the one-time Todo.md import so the Future tab shows only
+    // the wishlist items this test saves.
+    await File('${tempDir.path}/${StorageService.wishlistImportFlagFileName}')
+        .writeAsString('done');
+  });
+
+  Future<void> pumpHome(
+    WidgetTester tester, {
+    required List<Task> tasks,
+    required List<Task> wishlist,
+    required String marker,
+    int initialTabIndex = 0,
+  }) async {
+    // All real file I/O (pre-saving, HomePage's initState loads) must run on
+    // the real event loop via runAsync, not the fake-async test zone.
+    await tester.runAsync(() async {
+      final storage = StorageService();
+      await storage.saveTaskList(tasks);
+      await storage.saveWishlist(wishlist);
+    });
+    await tester.pumpWidget(
+      MaterialApp(home: HomePage(initialTabIndex: initialTabIndex)),
+    );
+    final markerFinder = find.text(marker);
+    for (var i = 0; i < 300 && markerFinder.evaluate().isEmpty; i++) {
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 5)));
+      await tester.pump();
+    }
+    await tester.pumpAndSettle();
+    expect(markerFinder, findsOneWidget,
+        reason: 'HomePage never loaded the tasks');
+  }
+
+  final futureDue = DateTime(2300, 1, 1);
+
+  testWidgets('wishlist items appear on the Future tab tagged "wish"',
+      (tester) async {
+    await pumpHome(
+      tester,
+      tasks: [Task(title: 'Plan world trip', dueDate: futureDue)],
+      wishlist: [
+        Task(
+          title: 'Buy a telescope',
+          description: 'For stargazing weekends',
+          label: 'gift',
+        ),
+      ],
+      marker: 'Plan world trip',
+      initialTabIndex: 5,
+    );
+
+    // Real future tasks and wishlist items render side by side; the wish
+    // tile carries a "wish" chip plus its own labels.
+    expect(find.text('Buy a telescope'), findsOneWidget);
+    expect(find.text('For stargazing weekends'), findsOneWidget);
+    expect(find.text('wish'), findsOneWidget);
+    expect(find.text('gift'), findsOneWidget);
+  });
+
+  testWidgets('wishlist items do not appear on the Today tab',
+      (tester) async {
+    await pumpHome(
+      tester,
+      tasks: [Task(title: 'Feed the zebra', dueDate: DateTime.now())],
+      wishlist: [Task(title: 'Buy a telescope', label: 'gift')],
+      marker: 'Feed the zebra',
+    );
+
+    expect(find.text('Buy a telescope'), findsNothing);
+    expect(find.text('wish'), findsNothing);
+  });
+}

--- a/test/tools/wishlist_migration_test.dart
+++ b/test/tools/wishlist_migration_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:besttodo/models/task.dart';
+import 'package:besttodo/services/storage_service.dart';
+import 'package:besttodo/services/wishlist_migration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.path);
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+  });
+
+  File flagFile() =>
+      File('${tempDir.path}/${StorageService.wishlistImportFlagFileName}');
+
+  test('first load imports the Todo.md backlog labelled "old"', () async {
+    final items = await StorageService().loadWishlist();
+
+    expect(items.length, legacyTodoWishlistItems.length);
+    expect(items.every((t) => t.label == legacyTodoImportLabel), isTrue);
+    expect(items.map((t) => t.title), contains('calendar view'));
+    expect(items.map((t) => t.title), contains('web version'));
+
+    // The merged list is persisted and the run-once flag written.
+    expect(File('${tempDir.path}/wishlist.json').existsSync(), isTrue);
+    expect(flagFile().existsSync(), isTrue);
+  });
+
+  test('existing items are kept and matching titles are not duplicated',
+      () async {
+    final service = StorageService();
+    // Same title as a backlog entry, differing only in case and whitespace.
+    await service.saveWishlist([
+      Task(title: 'Buy a telescope', label: 'gift'),
+      Task(title: 'Calendar  View', label: 'ui'),
+    ]);
+
+    final items = await service.loadWishlist();
+
+    expect(items.map((t) => t.title), contains('Buy a telescope'));
+    final calendarish = items
+        .where((t) => normalizeWishlistTitle(t.title) == 'calendar view')
+        .toList();
+    expect(calendarish.length, 1);
+    // The user's own item is untouched, including its label.
+    expect(calendarish.single.title, 'Calendar  View');
+    expect(calendarish.single.label, 'ui');
+    expect(items.length, 1 + legacyTodoWishlistItems.length);
+  });
+
+  test('import runs only once, so deleting an imported item sticks', () async {
+    final service = StorageService();
+    final first = await service.loadWishlist();
+    first.removeWhere(
+        (t) => normalizeWishlistTitle(t.title) == 'web version');
+    await service.saveWishlist(first);
+
+    final second = await service.loadWishlist();
+
+    expect(
+      second.where((t) => normalizeWishlistTitle(t.title) == 'web version'),
+      isEmpty,
+    );
+    expect(second.length, legacyTodoWishlistItems.length - 1);
+  });
+
+  test('an unreadable wishlist file is never overwritten by the import',
+      () async {
+    final file = File('${tempDir.path}/wishlist.json');
+    await file.writeAsString('not json');
+
+    final items = await StorageService().loadWishlist();
+
+    expect(items, isEmpty);
+    expect(await file.readAsString(), 'not json');
+    // No flag either: the import stays pending until the file is readable.
+    expect(flagFile().existsSync(), isFalse);
+  });
+
+  test('backlog titles are unique after normalization', () {
+    final normalized =
+        legacyTodoWishlistItems.map((i) => normalizeWishlistTitle(i.title));
+    expect(normalized.toSet().length, legacyTodoWishlistItems.length);
+  });
+}


### PR DESCRIPTION
## What this does

- **Future tab now mirrors the wishlist**: every `wishlist.json` item renders below the real future tasks as a read-only card tagged with a `wish` chip (plus its own labels). Search filters them, tapping opens the Wishlist tool, and they are kept strictly out of `_tasks`/`tasks.json`, stats, schedule view and reorder logic.
- **One-time Todo.md → wishlist import**: the 63 still-open ideas from `Todo.md` (After MVP TODO + Later sections; DONE excluded) are merged into the wishlist labelled `old` on first load. Dedup by normalized title, existing items never modified/removed, guarded by a flag file so deletions stick, and a wishlist file that fails to parse is never overwritten.
- Tests: `test/tools/wishlist_migration_test.dart` (import / dedup / run-once / corrupt-file safety / backlog uniqueness) and `test/home/home_future_wishlist_test.dart` (wish chip on Future tab, absent on Today).
- Docs: SPEC §10.6 Wishlist, `test/README.md` map, CHANGELOG; version bumped to 0.1.100+70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsBWTxtzYSzkoNPpWTjJYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsBWTxtzYSzkoNPpWTjJYo)_