### PR TITLE
Add per-timer round-number notifications to Countdown (0.1.97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.99] - 2026-07-17
+- Countdown: the round-number bell now also works for past timers counting up — get a notification when the elapsed time crosses a round number of seconds (e.g. 1,000,000,000 seconds since your birthday, about 31.7 years)
+
 ## [0.1.98] - 2026-07-17
 - Countdown: timers can now be set in the past — the date picker goes back to 1900, so you can track how long since your birthday or any other past event (past timers count up, and the expanded card shows the total in days, weeks, months and years)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.98] - 2026-07-17
+- Countdown: timers can now be set in the past — the date picker goes back to 1900, so you can track how long since your birthday or any other past event (past timers count up, and the expanded card shows the total in days, weeks, months and years)
+
 ## [0.1.97] - 2026-07-17
 - Countdown: new per-timer round-number bell (# icon next to the zero bell) — get a notification whenever the remaining time crosses a round number of seconds: 1,000,000,000 down to 1,000 in powers of ten (100,000 seconds is about 1.2 days before the event)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.97] - 2026-07-17
+- Countdown: new per-timer round-number bell (# icon next to the zero bell) — get a notification whenever the remaining time crosses a round number of seconds: 1,000,000,000 down to 1,000 in powers of ten (100,000 seconds is about 1.2 days before the event)
+
 ## [0.1.96] - 2026-07-09
 - release builds now embed the CI test results: if a test failed on GitHub while the APK still built, the menu (hamburger) icon shows a red dot and a new Test Results page in the menu lists the current build's failing tests
 - Settings: search your settings — a magnifier in the Settings title bar filters all settings by name or keyword and jumps to the matching section (separate from the task search on the home screen)

--- a/SPEC.md
+++ b/SPEC.md
@@ -500,7 +500,8 @@ target now+7d, minimizes on scroll), in-place edit, drag reorder (manual mode) o
 name/added/edited/deadline asc/desc, swipe-to-delete with undo, 1 s tick. Collapsed rows
 show whole-unit breakdowns ("in 2mo 1w 3d 4h"); expanded shows the same duration as
 decimals in every unit (years=days/365.25, months=days/30.4375, …). Past timers count up
-(orange). Notify-on-zero fires a notification once (suppressed for already-past timers so
+(orange); the instant date picker ranges 1900 → now+100y (0.1.98) so past events
+(birthdays) can be created directly. Notify-on-zero fires a notification once (suppressed for already-past timers so
 they never retro-fire; suppression is per-session). Notify-at-round-numbers (# icon,
 per-timer, 0.1.97) fires whenever the remaining time crosses a power-of-ten second count
 (1e9 → 1e3; `CountdownTimerItem.roundMilestones`/`crossedRoundMilestone`): the page

--- a/SPEC.md
+++ b/SPEC.md
@@ -494,14 +494,19 @@ with coarse distances ("3 hours"); tap to glide there. Tap empty timeline → cr
 (5-min rounded time); tap chip → edit dialog (sets `hasExplicitTime`).
 
 ### 10.2 Countdown timers (Tools → Countdown)
-`CountdownTimerItem{uid,label,target,notifyOnZero,createdAt,editedAt}` in
-`countdown_timers.json`. Inline always-present composer (auto-names "Timer N", default
+`CountdownTimerItem{uid,label,target,notifyOnZero,notifyRoundNumbers,createdAt,editedAt}`
+in `countdown_timers.json`. Inline always-present composer (auto-names "Timer N", default
 target now+7d, minimizes on scroll), in-place edit, drag reorder (manual mode) or sort by
 name/added/edited/deadline asc/desc, swipe-to-delete with undo, 1 s tick. Collapsed rows
 show whole-unit breakdowns ("in 2mo 1w 3d 4h"); expanded shows the same duration as
 decimals in every unit (years=days/365.25, months=days/30.4375, …). Past timers count up
 (orange). Notify-on-zero fires a notification once (suppressed for already-past timers so
-they never retro-fire; suppression is per-session).
+they never retro-fire; suppression is per-session). Notify-at-round-numbers (# icon,
+per-timer, 0.1.97) fires whenever the remaining time crosses a power-of-ten second count
+(1e9 → 1e3; `CountdownTimerItem.roundMilestones`/`crossedRoundMilestone`): the page
+tracks last-seen remaining seconds per timer (`_roundSeen`, per-session), the first
+observation only baselines (no retro-fire on load/toggle/edit), and a jump across
+several milestones (backgrounded app) fires only the smallest one crossed.
 
 ### 10.3 Productivity Stats (formerly "Your Stats"; lives under Tools since 0.1.91)
 Three sections: (a) GitHub-style 52-week × 7-day heatmap of **deleted-per-day** counts

--- a/SPEC.md
+++ b/SPEC.md
@@ -503,11 +503,14 @@ decimals in every unit (years=days/365.25, months=days/30.4375, …). Past timer
 (orange); the instant date picker ranges 1900 → now+100y (0.1.98) so past events
 (birthdays) can be created directly. Notify-on-zero fires a notification once (suppressed for already-past timers so
 they never retro-fire; suppression is per-session). Notify-at-round-numbers (# icon,
-per-timer, 0.1.97) fires whenever the remaining time crosses a power-of-ten second count
-(1e9 → 1e3; `CountdownTimerItem.roundMilestones`/`crossedRoundMilestone`): the page
-tracks last-seen remaining seconds per timer (`_roundSeen`, per-session), the first
-observation only baselines (no retro-fire on load/toggle/edit), and a jump across
-several milestones (backgrounded app) fires only the smallest one crossed.
+per-timer, 0.1.97) fires whenever the remaining time — or, for past timers, the elapsed
+time (0.1.99) — crosses a power-of-ten second count (1e9 → 1e3;
+`CountdownTimerItem.roundMilestones` / `crossedRoundMilestone` /
+`crossedRoundMilestoneUp`): the page tracks last-seen signed remaining seconds per timer
+(`_roundSeen`, negative once past; per-session), the first observation only baselines
+(no retro-fire on load/toggle/edit), and a jump across several milestones (backgrounded
+app) fires only the most recent one crossed (smallest counting down, largest counting
+up).
 
 ### 10.3 Productivity Stats (formerly "Your Stats"; lives under Tools since 0.1.91)
 Three sections: (a) GitHub-style 52-week × 7-day heatmap of **deleted-per-day** counts

--- a/lib/models/countdown_timer.dart
+++ b/lib/models/countdown_timer.dart
@@ -13,6 +13,10 @@ class CountdownTimerItem {
   /// When true, a notification fires once when the timer reaches zero.
   bool notifyOnZero;
 
+  /// When true, a notification fires each time the remaining time crosses a
+  /// round number of seconds (one of [roundMilestones]).
+  bool notifyRoundNumbers;
+
   /// When the timer was first created and last edited — used for sorting.
   DateTime createdAt;
   DateTime editedAt;
@@ -22,6 +26,7 @@ class CountdownTimerItem {
     required this.label,
     required this.target,
     this.notifyOnZero = false,
+    this.notifyRoundNumbers = false,
     DateTime? createdAt,
     DateTime? editedAt,
   })  : uid = uid ?? CountdownTimerItem.newUid(),
@@ -40,9 +45,43 @@ class CountdownTimerItem {
       label: json['label'] as String? ?? '',
       target: DateTime.parse(json['target'] as String),
       notifyOnZero: json['notifyOnZero'] as bool? ?? false,
+      notifyRoundNumbers: json['notifyRoundNumbers'] as bool? ?? false,
       createdAt: created,
       editedAt: edited,
     );
+  }
+
+  /// Remaining-seconds milestones the round-number bell notifies at, largest
+  /// first: powers of ten from 1,000,000,000 down to 1,000 seconds
+  /// (100,000 s ≈ 1.2 days out; zero itself is the notify-on-zero bell's job).
+  static const List<int> roundMilestones = [
+    1000000000,
+    100000000,
+    10000000,
+    1000000,
+    100000,
+    10000,
+    1000,
+  ];
+
+  /// The milestone most recently crossed while the remaining time fell from
+  /// [previousSeconds] to [currentSeconds], or null when none was crossed.
+  /// A crossing means the remaining time was strictly above the milestone
+  /// before and is at or below it now; when several were crossed at once
+  /// (e.g. after the app was backgrounded) only the smallest — the most
+  /// recent — is reported. A timer at or past zero reports nothing.
+  static int? crossedRoundMilestone({
+    required int previousSeconds,
+    required int currentSeconds,
+  }) {
+    if (currentSeconds <= 0) return null;
+    int? crossed;
+    for (final milestone in roundMilestones) {
+      if (previousSeconds > milestone && currentSeconds <= milestone) {
+        crossed = milestone;
+      }
+    }
+    return crossed;
   }
 
   Map<String, dynamic> toJson() => {
@@ -50,6 +89,7 @@ class CountdownTimerItem {
         'label': label,
         'target': target.toIso8601String(),
         'notifyOnZero': notifyOnZero,
+        'notifyRoundNumbers': notifyRoundNumbers,
         'createdAt': createdAt.toIso8601String(),
         'editedAt': editedAt.toIso8601String(),
       };

--- a/lib/models/countdown_timer.dart
+++ b/lib/models/countdown_timer.dart
@@ -51,9 +51,11 @@ class CountdownTimerItem {
     );
   }
 
-  /// Remaining-seconds milestones the round-number bell notifies at, largest
+  /// Second-count milestones the round-number bell notifies at, largest
   /// first: powers of ten from 1,000,000,000 down to 1,000 seconds
-  /// (100,000 s ≈ 1.2 days out; zero itself is the notify-on-zero bell's job).
+  /// (100,000 s ≈ 1.2 days). Applied to the remaining time while counting
+  /// down and to the elapsed time while counting up; zero itself is the
+  /// notify-on-zero bell's job.
   static const List<int> roundMilestones = [
     1000000000,
     100000000,
@@ -82,6 +84,24 @@ class CountdownTimerItem {
       }
     }
     return crossed;
+  }
+
+  /// Count-up counterpart of [crossedRoundMilestone]: the milestone most
+  /// recently crossed while the elapsed time rose from [previousSeconds] to
+  /// [currentSeconds], or null when none was crossed. A crossing means the
+  /// elapsed time was strictly below the milestone before and is at or above
+  /// it now; when several were crossed at once only the largest — the most
+  /// recent — is reported.
+  static int? crossedRoundMilestoneUp({
+    required int previousSeconds,
+    required int currentSeconds,
+  }) {
+    for (final milestone in roundMilestones) {
+      if (previousSeconds < milestone && currentSeconds >= milestone) {
+        return milestone;
+      }
+    }
+    return null;
   }
 
   Map<String, dynamic> toJson() => {

--- a/lib/ui/countdown_timer_page.dart
+++ b/lib/ui/countdown_timer_page.dart
@@ -32,9 +32,10 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
   final Set<String> _notifySuppressed = {};
 
   /// Last observed remaining whole seconds per timer with the round-number
-  /// bell on. The first observation only records a baseline (so switching the
-  /// bell on or opening the page never retro-fires for milestones already
-  /// passed); crossings are detected against it on later ticks. Not persisted.
+  /// bell on — negative once the timer is past (counting up). The first
+  /// observation only records a baseline (so switching the bell on or opening
+  /// the page never retro-fires for milestones already passed); crossings are
+  /// detected against it on later ticks. Not persisted.
   final Map<String, int> _roundSeen = {};
 
   Timer? _ticker;
@@ -155,22 +156,30 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
         _roundSeen.remove(t.uid);
         continue;
       }
+      // Positive while counting down, negative once past (counting up).
       final remaining = t.target.difference(now).inSeconds;
-      if (remaining <= 0) {
-        _roundSeen.remove(t.uid);
-        continue;
-      }
       final previous = _roundSeen[t.uid];
       _roundSeen[t.uid] = remaining;
       if (previous == null) continue;
-      final milestone = CountdownTimerItem.crossedRoundMilestone(
-        previousSeconds: previous,
-        currentSeconds: remaining,
-      );
+      final int? milestone;
+      final String suffix;
+      if (remaining > 0) {
+        milestone = CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: previous,
+          currentSeconds: remaining,
+        );
+        suffix = 'seconds to go';
+      } else {
+        milestone = CountdownTimerItem.crossedRoundMilestoneUp(
+          previousSeconds: -previous,
+          currentSeconds: -remaining,
+        );
+        suffix = 'seconds since';
+      }
       if (milestone != null) {
         final name = t.label.trim().isEmpty ? 'Countdown' : t.label.trim();
         NotificationService.showTaskNotification(
-          '$name — ${_formatThousands(milestone)} seconds to go',
+          '$name — ${_formatThousands(milestone)} $suffix',
           delaySeconds: 0,
         );
       }

--- a/lib/ui/countdown_timer_page.dart
+++ b/lib/ui/countdown_timer_page.dart
@@ -31,6 +31,12 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
   /// switched on. Not persisted.
   final Set<String> _notifySuppressed = {};
 
+  /// Last observed remaining whole seconds per timer with the round-number
+  /// bell on. The first observation only records a baseline (so switching the
+  /// bell on or opening the page never retro-fires for milestones already
+  /// passed); crossings are detected against it on later ticks. Not persisted.
+  final Map<String, int> _roundSeen = {};
+
   Timer? _ticker;
   bool _loading = true;
 
@@ -57,6 +63,7 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
     _listController.addListener(_handleListScroll);
     _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
       _checkZeroNotifications();
+      _checkRoundNotifications();
       if (mounted) setState(() {});
     });
   }
@@ -109,6 +116,7 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
       CountdownTimerItem(
         label: 'New Year',
         target: DateTime(now.year + 1, 1, 1, 0, 0),
+        notifyRoundNumbers: true,
       ),
       CountdownTimerItem(
         label: 'Project deadline',
@@ -140,6 +148,45 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
     }
   }
 
+  void _checkRoundNotifications() {
+    final now = DateTime.now();
+    for (final t in _timers) {
+      if (!t.notifyRoundNumbers) {
+        _roundSeen.remove(t.uid);
+        continue;
+      }
+      final remaining = t.target.difference(now).inSeconds;
+      if (remaining <= 0) {
+        _roundSeen.remove(t.uid);
+        continue;
+      }
+      final previous = _roundSeen[t.uid];
+      _roundSeen[t.uid] = remaining;
+      if (previous == null) continue;
+      final milestone = CountdownTimerItem.crossedRoundMilestone(
+        previousSeconds: previous,
+        currentSeconds: remaining,
+      );
+      if (milestone != null) {
+        final name = t.label.trim().isEmpty ? 'Countdown' : t.label.trim();
+        NotificationService.showTaskNotification(
+          '$name — ${_formatThousands(milestone)} seconds to go',
+          delaySeconds: 0,
+        );
+      }
+    }
+  }
+
+  String _formatThousands(int n) {
+    final s = n.toString();
+    final b = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      if (i > 0 && (s.length - i) % 3 == 0) b.write(',');
+      b.write(s[i]);
+    }
+    return b.toString();
+  }
+
   /// Switches the given timer's row into the inline editor (same UI as adding).
   void _editTimer(CountdownTimerItem timer) {
     setState(() => _editingUid = timer.uid);
@@ -160,6 +207,8 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
       if (timer.notifyOnZero && !timer.target.isAfter(DateTime.now())) {
         _notifySuppressed.add(timer.uid);
       }
+      // Re-baseline round-number tracking against the new target.
+      _roundSeen.remove(timer.uid);
       _editingUid = null;
     });
     await _save();
@@ -178,6 +227,16 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
       } else {
         _notifySuppressed.remove(timer.uid);
       }
+    });
+    _save();
+  }
+
+  void _toggleRoundNotify(CountdownTimerItem timer) {
+    setState(() {
+      timer.notifyRoundNumbers = !timer.notifyRoundNumbers;
+      // Tracking re-baselines on the next tick; clearing here covers both
+      // switching off and switching back on after a target change.
+      _roundSeen.remove(timer.uid);
     });
     _save();
   }
@@ -476,6 +535,18 @@ class _CountdownTimerPageState extends State<CountdownTimerPage> {
                       ? 'Notify at zero: on'
                       : 'Notify at zero: off',
                   onPressed: () => _toggleNotify(timer),
+                ),
+                IconButton(
+                  icon: Icon(
+                    Icons.tag,
+                    color: timer.notifyRoundNumbers
+                        ? Theme.of(context).colorScheme.primary
+                        : null,
+                  ),
+                  tooltip: timer.notifyRoundNumbers
+                      ? 'Notify at round numbers: on'
+                      : 'Notify at round numbers: off',
+                  onPressed: () => _toggleRoundNotify(timer),
                 ),
               ],
             ),

--- a/lib/utils/date_time_format.dart
+++ b/lib/utils/date_time_format.dart
@@ -53,7 +53,9 @@ String formatTimerDateTime(DateTime d) =>
 /// no separate OK/Cancel step. Selecting a year or navigating months does not
 /// close it. Returns null if dismissed without a selection.
 Future<DateTime?> pickDateInstantly(BuildContext context, DateTime initial) {
-  final firstDate = DateTime(2000);
+  // A century back and forward: past dates make count-up timers (days since
+  // a birthday etc.), future dates make countdowns.
+  final firstDate = DateTime(1900);
   final lastDate = DateTime(DateTime.now().year + 100);
   // Clamp the initial date into range so CalendarDatePicker never asserts.
   var initialDate = initial;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.98+68
+version: 0.1.99+69
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.96+66
+version: 0.1.97+67
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: besttodo
 description: A simple Flutter to-do application
 publish_to: 'none'
 
-version: 0.1.97+67
+version: 0.1.98+68
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/README.md
+++ b/test/README.md
@@ -13,7 +13,7 @@ other suites are per-feature silos: run the ones whose area you touched.
 | `test/alarms/` | `flutter test test/alarms` | Alarm model, `AlarmStorageService` round-trip, alarm editor (top save), alarm ring page |
 | `test/projects/` | `flutter test test/projects` | Project model, `ProjectService` (seed/rename/reload/corrupt file), Projects page drag-assign, Kanban board page, task-tile project/stage tags |
 | `test/home/` | `flutter test test/home` | Home page UI: search behaviors, drawer layout (Projects under Tools), task-tile description editing, test-failure red dot on the hamburger/drawer, settings search |
-| `test/tools/` | `flutter test test/tools` | Auxiliary tools: export/import + analytics CSVs, usage-data service, startup-times page, countdown timer model, chronize page, CI test report model/parser + Test Results page |
+| `test/tools/` | `flutter test test/tools` | Auxiliary tools: export/import + analytics CSVs, usage-data service, startup-times page, countdown timer model, timer date picker (`lib/utils/date_time_format.dart`), chronize page, CI test report model/parser + Test Results page |
 
 ## Which suites to run
 

--- a/test/tools/countdown_timer_model_test.dart
+++ b/test/tools/countdown_timer_model_test.dart
@@ -127,6 +127,65 @@ void main() {
       );
     });
 
+    test('count-up: reports a milestone once the elapsed time reaches it', () {
+      expect(
+        CountdownTimerItem.crossedRoundMilestoneUp(
+          previousSeconds: 99999,
+          currentSeconds: 100001,
+        ),
+        100000,
+      );
+      // Landing exactly on the milestone counts as crossing it.
+      expect(
+        CountdownTimerItem.crossedRoundMilestoneUp(
+          previousSeconds: 99999,
+          currentSeconds: 100000,
+        ),
+        100000,
+      );
+    });
+
+    test('count-up: reports nothing without a crossing', () {
+      // Still below the milestone.
+      expect(
+        CountdownTimerItem.crossedRoundMilestoneUp(
+          previousSeconds: 99998,
+          currentSeconds: 99999,
+        ),
+        isNull,
+      );
+      // Already at the milestone before — no re-fire while sitting above it.
+      expect(
+        CountdownTimerItem.crossedRoundMilestoneUp(
+          previousSeconds: 100000,
+          currentSeconds: 100001,
+        ),
+        isNull,
+      );
+      // Just crossed zero — nothing until 1,000 s elapsed.
+      expect(
+        CountdownTimerItem.crossedRoundMilestoneUp(
+          previousSeconds: -5,
+          currentSeconds: 3,
+        ),
+        isNull,
+      );
+    });
+
+    test('count-up: reports only the most recent milestone after a large jump',
+        () {
+      // e.g. the app was closed from 9,000 s elapsed until 2,000,000 s
+      // elapsed: 10,000 / 100,000 / 1,000,000 were all passed; only the
+      // latest (largest) fires.
+      expect(
+        CountdownTimerItem.crossedRoundMilestoneUp(
+          previousSeconds: 9000,
+          currentSeconds: 2000000,
+        ),
+        1000000,
+      );
+    });
+
     test('milestones are the descending powers of ten from 1e9 to 1e3', () {
       expect(CountdownTimerItem.roundMilestones, [
         1000000000,

--- a/test/tools/countdown_timer_model_test.dart
+++ b/test/tools/countdown_timer_model_test.dart
@@ -11,6 +11,7 @@ void main() {
       label: 'Launch',
       target: DateTime(2026, 6, 1, 12, 0),
       notifyOnZero: true,
+      notifyRoundNumbers: true,
       createdAt: created,
       editedAt: edited,
     );
@@ -20,6 +21,7 @@ void main() {
     expect(restored.uid, 'abc');
     expect(restored.label, 'Launch');
     expect(restored.notifyOnZero, isTrue);
+    expect(restored.notifyRoundNumbers, isTrue);
     expect(restored.createdAt, created);
     expect(restored.editedAt, edited);
     expect(restored.target, DateTime(2026, 6, 1, 12, 0));
@@ -45,5 +47,96 @@ void main() {
     // Missing timestamps fall back to a sensible non-null default.
     expect(item.createdAt, isNotNull);
     expect(item.editedAt, isNotNull);
+    // Missing round-number flag defaults to off.
+    expect(item.notifyRoundNumbers, isFalse);
+  });
+
+  group('crossedRoundMilestone', () {
+    test('reports a milestone once the remaining time falls to or below it',
+        () {
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 100001,
+          currentSeconds: 99999,
+        ),
+        100000,
+      );
+      // Landing exactly on the milestone counts as crossing it.
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 100001,
+          currentSeconds: 100000,
+        ),
+        100000,
+      );
+    });
+
+    test('reports nothing without a crossing', () {
+      // Still above the milestone.
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 100002,
+          currentSeconds: 100001,
+        ),
+        isNull,
+      );
+      // Already at the milestone before — no re-fire while sitting below it.
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 100000,
+          currentSeconds: 99999,
+        ),
+        isNull,
+      );
+      // Between milestones the whole time.
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 5000,
+          currentSeconds: 4000,
+        ),
+        isNull,
+      );
+    });
+
+    test('reports only the most recent milestone after a large jump', () {
+      // e.g. the app was backgrounded from 2,000,000 s out until 9,000 s out:
+      // 1,000,000 / 100,000 / 10,000 were all passed; only the latest fires.
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 2000000,
+          currentSeconds: 9000,
+        ),
+        10000,
+      );
+    });
+
+    test('reports nothing for a timer at or past zero', () {
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 1500,
+          currentSeconds: 0,
+        ),
+        isNull,
+      );
+      expect(
+        CountdownTimerItem.crossedRoundMilestone(
+          previousSeconds: 1500,
+          currentSeconds: -10,
+        ),
+        isNull,
+      );
+    });
+
+    test('milestones are the descending powers of ten from 1e9 to 1e3', () {
+      expect(CountdownTimerItem.roundMilestones, [
+        1000000000,
+        100000000,
+        10000000,
+        1000000,
+        100000,
+        10000,
+        1000,
+      ]);
+    });
   });
 }

--- a/test/tools/date_time_format_picker_test.dart
+++ b/test/tools/date_time_format_picker_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:besttodo/utils/date_time_format.dart';
+
+void main() {
+  testWidgets('pickDateInstantly supports dates back to 1900', (tester) async {
+    DateTime? picked;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () async {
+                picked = await pickDateInstantly(context, DateTime(1985, 6, 15));
+              },
+              child: const Text('pick'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('pick'));
+    await tester.pumpAndSettle();
+
+    // Before the range was widened to 1900, an initial date before 2000 was
+    // clamped up to 2000; the calendar must open on the requested month.
+    expect(find.textContaining('1985'), findsWidgets);
+
+    // Tapping a day closes the instant picker and returns the past date.
+    await tester.tap(find.text('20'));
+    await tester.pumpAndSettle();
+    expect(picked, DateTime(1985, 6, 20));
+  });
+}


### PR DESCRIPTION
A new # bell on each countdown card fires a notification whenever the
remaining time crosses a round number of seconds (powers of ten from
1,000,000,000 down to 1,000 — 100,000 s is ~1.2 days before the event).
Crossing detection lives in CountdownTimerItem.crossedRoundMilestone so
it is unit-tested; the page baselines last-seen remaining seconds per
timer so switching the bell on, editing a target, or reopening the page
never retro-fires, and a jump across several milestones (backgrounded
app) fires only the most recent one.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HsJsZg6jTkGGxFGSE9SEdT